### PR TITLE
 Add option to ignore license check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 terraform-provider-infoblox
 example
+*.swp
+

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -99,7 +99,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	requestor := &ibclient.WapiHttpRequestor{}
 
 	conn, err := ibclient.NewConnector(hostConfig, transportConfig, requestBuilder, requestor)
-	objMgr := ibclient.NewObjectManager(conn, "", "")
+	objMgr := ibclient.NewObjectManager(conn, "infoblox", "terraform-provider-infoblox")
 	err = CheckCloudLicense(objMgr, "cloud")
 	if err != nil {
 		return nil, err

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -97,13 +97,18 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	requestBuilder := &ibclient.WapiRequestBuilder{}
 	requestor := &ibclient.WapiHttpRequestor{}
-
 	conn, err := ibclient.NewConnector(hostConfig, transportConfig, requestBuilder, requestor)
-	objMgr := ibclient.NewObjectManager(conn, "infoblox", "terraform-provider-infoblox")
-	err = CheckCloudLicense(objMgr, "cloud")
-	if err != nil {
-		return nil, err
+
+	licenseNocheck := schema.EnvDefaultFunc("LICENSE_NOCHECK", nil)
+
+	if licenseNocheck == nil {
+		objMgr := ibclient.NewObjectManager(conn, "infoblox", "terraform-provider-infoblox")
+		err = CheckCloudLicense(objMgr, "cloud")
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return conn, err
 }
 


### PR DESCRIPTION
That fix is necessary to use with Infoblox instances running in-house.