### PR TITLE
update gopkg.toml to allow any TF version greater than 0.11.3

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/terraform"
-  version = "0.11.3"
+  version = ">=0.11.3"
 
 [[constraint]]
   name = "github.com/infobloxopen/infoblox-go-client"


### PR DESCRIPTION
Re: issue #29 

This change allows the provider to be built with any Terraform version equal to or greater than 0.11.3 (instead of requiring exactly 0.11.3). I confirmed the syntax using the [Gopkg.toml docs](https://golang.github.io/dep/docs/Gopkg.toml.html).

@saiprasannasastry : Can you confirm that this was the change that you had in mind?