### PR TITLE
Check that parent exists before network allocation.

### DIFF
--- a/infoblox/resource_infoblox_network.go
+++ b/infoblox/resource_infoblox_network.go
@@ -85,6 +85,14 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 	var network *ibclient.Network
 	var err error
 	if cidr == "" && parent_cidr != "" && prefixLen > 1 {
+		network_container, err := objMgr.GetNetworkContainer(networkViewName, parent_cidr)
+		if network_container == nil {
+			return fmt.Errorf(
+				"Allocation of network block failed in network view (%s) : Parent network container %s not found.",
+				networkViewName, parent_cidr)
+
+		}
+
 		network, err = objMgr.AllocateNetwork(networkViewName, parent_cidr, uint(prefixLen), networkName)
 		if err != nil {
 			return fmt.Errorf("Allocation of network block failed in network view (%s) : %s", networkViewName, err)

--- a/infoblox/resource_infoblox_network_test.go
+++ b/infoblox/resource_infoblox_network_test.go
@@ -2,6 +2,7 @@ package infoblox
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -45,6 +46,21 @@ func TestAccresourceNetwork_Allocate(t *testing.T) {
 					testAccCreateNetworkExists(t, "infoblox_network.foo0", "10.0.0.0/24", "default", "demo-network"),
 					testAccCreateNetworkExists(t, "infoblox_network.foo1", "10.0.1.0/24", "default", "demo-network"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccresourceNetwork_Allocate_Fail(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccresourceNetworkAllocateFail,
+				ExpectError: regexp.MustCompile(`Allocation of network block failed in network view \(default\) : Parent network container 11.11.0.0/16 not found.`),
 			},
 		},
 	})
@@ -115,6 +131,16 @@ resource "infoblox_network" "foo1"{
 	tenant_id="foo"
 	allocate_prefix_len=24
 	parent_cidr="10.0.0.0/16"
+	}`)
+
+/* Network container 11.11.0.0 should NOT exists to pass this test */
+var testAccresourceNetworkAllocateFail = fmt.Sprintf(`
+resource "infoblox_network" "foo0"{
+	network_view_name="default"
+	network_name="demo-network"
+	tenant_id="foo"
+	allocate_prefix_len=24
+	parent_cidr="11.11.0.0/16"
 	}`)
 
 var testAccresourceNetworkUpdate = fmt.Sprintf(`


### PR DESCRIPTION
NIOS convert parent network to network container when network
inserted into network.
After such convertion caused parent network ID changed to network
container ID, so parent will be unavailable to terraform.
To prevent it - add check that parent is network container before
network allocation.