### PR TITLE
ForceNew CNAMEs upon edit

### DIFF
--- a/infoblox/resource_infoblox_cname_record.go
+++ b/infoblox/resource_infoblox_cname_record.go
@@ -20,6 +20,7 @@ func resourceCNAMERecord() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Zone under which record has to be created.",
 			},
 			"dns_view": &schema.Schema{
@@ -31,11 +32,13 @@ func resourceCNAMERecord() *schema.Resource {
 			"canonical": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The Canonical name for the record.",
 			},
 			"alias": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The alias name for the record.",
 			},
 			"vm_id": &schema.Schema{
@@ -46,6 +49,7 @@ func resourceCNAMERecord() *schema.Resource {
 			"tenant_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Unique identifier of your tenant in cloud.",
 			},
 		},


### PR DESCRIPTION
CNAMEs are not updatable and result in a Terraform apply failure. 

Issue to solve is https://github.com/infobloxopen/terraform-provider-infoblox/issues/80

Original work done by @deromemont here https://github.com/hashicorp/terraform-provider-infoblox/pull/41 . Copied to push into this new repo.