### PR TITLE
Custom extensible attributes for infoblox_ip_allocation resource

### DIFF
--- a/examples/VMware/HostRecord/infoblox.tf
+++ b/examples/VMware/HostRecord/infoblox.tf
@@ -18,6 +18,9 @@ resource "infoblox_ip_allocation" "demo_allocation"{
   enable_dns=true
   cidr="${infoblox_network.demo_network.cidr}"
   tenant_id="test"  
+  extattrs = {
+    "Site" = "Site1"
+  }
 }
 
 resource "infoblox_ip_association" "demo_associate"{

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -72,7 +72,7 @@ func Provider() terraform.ResourceProvider {
 			"infoblox_ptr_record":     resourcePTRRecord(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"infoblox_network": dataSourceNetwork(),
+			"infoblox_network":      dataSourceNetwork(),
 			"infoblox_a_record":     dataSourceARecord(),
 			"infoblox_cname_record": dataSourceCNameRecord(),
 		},

--- a/infoblox/resource_infoblox_ip_allocation_test.go
+++ b/infoblox/resource_infoblox_ip_allocation_test.go
@@ -2,10 +2,11 @@ package infoblox
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/infobloxopen/infoblox-go-client"
-	"testing"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func TestAccResourceIPAllocation(t *testing.T) {
@@ -19,12 +20,15 @@ func TestAccResourceIPAllocation(t *testing.T) {
 				Config: testAccresourceIPAllocationCreate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccIPExists(t, "infoblox_ip_allocation.foo", "10.0.0.1/24", "10.0.0.1", "default", "demo-network"),
+					resource.TestCheckResourceAttr("infoblox_ip_allocation.foo", "extattrs.Site", "Site1"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccresourceIPAllocationUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccIPExists(t, "infoblox_ip_allocation.foo", "10.0.0.1/24", "10.0.0.1", "default", "demo-network"),
+					resource.TestCheckResourceAttr("infoblox_ip_allocation.foo", "extattrs.Site", "Site2"),
+					resource.TestCheckResourceAttr("infoblox_ip_allocation.foo", "extattrs.IB Discovery Owned", "Test"),
 				),
 			},
 		},
@@ -76,6 +80,9 @@ resource "infoblox_ip_allocation" "foo"{
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	tenant_id="foo"
+	extattrs = {
+		"Site" = "Site1"
+	}
 	}`)
 
 var testAccresourceIPAllocationUpdate = fmt.Sprintf(`
@@ -85,4 +92,8 @@ resource "infoblox_ip_allocation" "foo"{
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	tenant_id="foo"
+	extattrs = {
+		"Site" = "Site2"
+		"IB Discovery Owned" = "Test"
+	}
 	}`)

--- a/website/docs/r/ip_allocation.html.markdown
+++ b/website/docs/r/ip_allocation.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `enable_dns` - (optional) A boolean value which either creates or not creates for DNS purposes
 * `ip_addr` - (Optional) If set , a record will be created in NIOS using a passed IP address value. Takes in a string. If no value is given, a next available IP address will be allocated in NIOS
 * `mac_addr` - (Optional) If not set , a reservation will be created in NIOS.
+* `extattrs` - (Optional) A map of extensible attributes as `{"ATTR_NAME" = "ATTR_VALUE"}`
 
 ## Additional Note
 


### PR DESCRIPTION
Re-openning #99 

Related to #81

Example

```hcl
resource "infoblox_ip_allocation" "foo"{
	network_view_name="default"
	vm_name="test-name"
	cidr="10.0.0.0/24"
	ip_addr="10.0.0.1"
	tenant_id="foo"
	extattrs = {
		"Site" = "Site2"
		"IB Discovery Owned" = "Test"
	}
	}
```