### PR TITLE
Make documentation and examples easier to read

### DIFF
--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -14,8 +14,8 @@ When applied, data such as _ref and Name will be returned.
 
 ## Example Usage
 
-```hcl
-#create a test network, if network already exists skip this resource block
+```terraform
+
 resource "infoblox_network" "test" {
   network_name = "test"
   cidr         = "10.0.23.0/24"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -9,25 +9,24 @@ description: |-
 
 The Infoblox provider is used to interact with Infoblox Grid objects.
 
-## Authentication
+## Usage
 
-The provider allows you to manage Infoblox credentials. The following methods for supplying credentials are supported:
-- Static credentials
-- Environmental variables
+```terraform
+terraform {
+  required_providers {
+    infoblox = {
+      source = "infobloxopen/infoblox"
+      version = "1.1.1"
+    }
+  }
+}
 
-### Static Credentials
-
-Static credentials can be provided in the Infoblox provider block. A typical provider configuration will look like this:
-
-```hcl
-provider "infoblox"{
-  version="~> 1.0"
-  username="infoblox_user"
-  password="infoblox"
-  server="10.0.0.1"
+provider "infoblox" {
+  username = "infoblox_user"
+  password = "infoblox_password"
+  server   = "10.0.0.1"
 }
 ```
-
 #### Argument Reference
 
 The following arguments are supported in the `provider` block:

--- a/website/docs/r/a_record.html.markdown
+++ b/website/docs/r/a_record.html.markdown
@@ -9,21 +9,18 @@ description: |-
 # infoblox\_a\_record
 
 Creates an A record in NIOS .
-
-When applied, A Record will be created in NIOS
-
 ## Example Usage
 
-```hcl
-resource "infoblox_a_record" "demo_record"{
+```terraform
+resource "infoblox_a_record" "demo_record" {
 
-  network_view_name="demo1"
-  vm_name="test"
-  cidr="10.0.0.0/24"
-  ip_addr="10.0.0.1" //use the ip address used in IP allocation
-  dns_view="default"
-  zone="aa.com"
-tenant_id="test"
+  network_view_name = "default"
+  vm_name           = "my-hostname"
+  cidr              = "10.0.0.0/24"
+  ip_addr           = "10.0.0.1" //use the ip address used in IP allocation
+  dns_view          = "default"
+  zone              = "domain.com"
+  tenant_id         = "test"
 }
 ```
 ## Argument Reference
@@ -34,7 +31,7 @@ The following arguments are supported:
 * `vm_name` - (Required) A name you want to associate with the IP address.
 * `vm_id` - (Optional) Updates the VM id of the vm used to provision
 * `cidr` - (Required) The network block in cidr format
-* `tenant_id` - (Required) Links the network  to a tenant
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `dns_view` - (Optional) The view which contains the details of the zone. If not provided , record will be created under default view
 * `zone` - (Required) The zone in which you want to update a host record
 * `ip_addr` - (Required) - The IP address you want to update in NIOS. Use the Same IP you have passed during IP allocation.

--- a/website/docs/r/cname_record.html.markdown
+++ b/website/docs/r/cname_record.html.markdown
@@ -4,23 +4,17 @@ page_title: "Infoblox: infoblox_cname_record"
 description: |-
   Creates a cname record in NIOS.
 ---
-
-
 # infoblox\_ptr\_allocation
 
 Creates an cname record in NIOS .
-
-When applied, cname Record will be created in NIOS
-
 ## Example Usage
 
-```hcl
-resource "infoblox_cname_record" "demo_cname"{
-
-  canonical="demo"
-  zone="aa.com"
-  alias="demo1"
-tenant_id="test"
+```terraform
+resource "infoblox_cname_record" "demo_cname" {
+  canonical = "my-hostname.domain.com"
+  zone      = "domain.com"
+  alias     = "demo1"
+  tenant_id = "test"
 }
 
 ```
@@ -30,7 +24,7 @@ The following arguments are supported:
 
 * `canonical` - (Required) A name you want to associate with the IP address.
 * `vm_id` - (Optional) Updates the VM id of the vm used to provision
-* `tenant_id` - (Required) Links the network  to a tenant
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `dns_view` - (Optional) The view which contains the details of the zone. If not provided , record will be created under default view
 * `zone` - (Required) The zone in which you want to update a host record
 * `alias`- (Required) Alias for you cname record

--- a/website/docs/r/ip_allocation.html.markdown
+++ b/website/docs/r/ip_allocation.html.markdown
@@ -5,20 +5,19 @@ description: |-
   Reserves an IP from a network in NIOS.
 ---
 
-
 # infoblox\_ip\_allocation
 
-Reserves an IP from a network in NIOS .
+Reserves an IP from a network in NIOS.
 
-When applied, a next free availabe ip will be Reserved. Additional constraints, such as zone,dns view , mac address can also be configured. The same resource can be used to create Fixed address or Host Record. To create Host record, the zone and dns view parameters need to be specified. 
+When applied, the next free availabe IP will be reserved. Additional constraints, such as `zone`, `dns_view`, and `mac_addr` can also be configured. The same resource can be used to create fixed address or host record. To create host record, the `zone` and `dns_view` parameters need to be specified. 
 
 ## Example Usage
 
-```hcl
-resource "infoblox_ip_allocation" "demo_allocation"{
-  vm_name="terraform-demo1"
-  cidr="10.0.0.0/24"
-  tenant_id="test"
+```terraform
+resource "infoblox_ip_allocation" "demo_allocation" {
+  vm_name   = "terraform-demo1"
+  cidr      = "10.0.0.0/24"
+  tenant_id = "test"
 }
 ```
 ## Argument Reference
@@ -28,7 +27,7 @@ The following arguments are supported:
 * `network_view_name` - (Optional) Unless specified the resource Reserves the IP under default network view
 * `vm_name` - (Required) A name you want to associate with the IP address.
 * `cidr` - (Required) The network block in cidr format
-* `tenant_id` - (Required) Links the network  to a tenant
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `dns_view` - (Optional) The view which contains the details of the zone.If not provided , record will be created under default view
 * `zone` - (Optional) The zone in which you want to create a host record
 * `enable_dns` - (optional) A boolean value which either creates or not creates for DNS purposes
@@ -37,4 +36,4 @@ The following arguments are supported:
 
 ## Additional Note
 
-Dont set the mac address if you are integrating with cloud providers to deploy a Vm and use Infoblox to give the IP address.
+Don't set the MAC address if you are integrating with cloud providers to deploy a VM and use Infoblox to give the IP address.

--- a/website/docs/r/ip_association.html.markdown
+++ b/website/docs/r/ip_association.html.markdown
@@ -8,23 +8,22 @@ description: |-
 
 # infoblox\_ip\_association
 
-Reserves an IP from a network in NIOS .
+Reserves an IP from a network in NIOS.
 
-When applied, the properties of an IP address in NIOS are updated. Additional constraints, such as zone,dns view , mac address can also be configured. The same resource can be used to update Fixed address or Host Record. To update Host record, the zone and dns view parameters need to be specified. 
+When applied, the properties of an IP address in NIOS are updated. Additional constraints, such as `zone`, `dns_view`, and the `mac_addr` can also be configured. The same resource can be used to update fixed address or host Record. To update a host record, the `zone` and `dns_view` parameters need to be specified. 
 
 ## Example Usage
 
-```hcl
+```terraform
 # The example is given with integration of vmware provider
-resource "infoblox_ip_association" "demo_associate"{
-  network_view_name="demo1"
-  vm_name="test"
-  cidr="10.0.0.0/24"
-  mac_addr ="${vsphere_virtual_machine.vm.network_interface.0.mac_address}"
-  ip_addr="${infoblox_ip_allocation.demo_allocation.ip_addr}"
-  vm_id ="${vsphere_virtual_machine.vm.0.id}"
-  tenant_id="test"
-
+resource "infoblox_ip_association" "demo_associate" {
+  network_view_name = "demo1"
+  vm_name           = "test"
+  cidr              = "10.0.0.0/24"
+  mac_addr          = vsphere_virtual_machine.vm.network_interface.0.mac_address
+  ip_addr           = infoblox_ip_allocation.demo_allocation.ip_addr
+  vm_id             = vsphere_virtual_machine.vm.0.id
+  tenant_id         = "test"
 }
 
 ```
@@ -36,7 +35,7 @@ The following arguments are supported:
 * `vm_name` - (Required) A name you want to associate with the IP address.
 * `vm_id` - (Required) Updates the VM id of the vm used to provision
 * `cidr` - (Required) The network block in cidr format
-* `tenant_id` - (Required) Links the network  to a tenant
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `dns_view` - (Optional) The view which contains the details of the zone. If not provided , record will be created under default view
 * `zone` - (Optional) The zone in which you want to update a host record
 * `ip_addr` - (Required) - The IP address you want to update in NIOS. Use the Same IP you have passed during IP allocation.

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -9,21 +9,16 @@ description: |-
 
 Creates a network on NIOS.
 
-When applied,The network will be created on NIOS and the first IP will be reserved as gateway. Additional constraints such as reserve ip, network name can be configured.
-
+When applied,The network will be created on NIOS and the first IP will be reserved as gateway. Additional constraints such as `reserve_ip` and `network_name` can be configured.
 
 ## Example Usage
 
-```hcl
-# Protect the master branch of the foo repository. Additionally, require that
-# the "ci/travis" context to be passing and only allow the engineers team merge
-# to the branch.
-resource "infoblox_network" "demo_network"{
-  cidr="10.0.0.0/24"
-  tenant_id="test"
+```terraform
+resource "infoblox_network" "demo_network" {
+  cidr      = "10.0.0.0/24"
+  tenant_id = "test"
 }
 ```
-
 
 ## Argument Reference
 
@@ -31,8 +26,8 @@ The following arguments are supported:
 
 * `network_view_name` - (Optional) Unless specified the resource creates network under default network view
 * `network_name` - (optional) Unless specified the resource does not associate any name to the network
-* `cidr` - (Required) The network block in cidr format
-* `tenant_id` - (Required) Links the network  to a tenant
+* `cidr` - (Required) The network block in CIDR format
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `reserve_ip` - (optional) reserves the number of Ip's for later use. Takes an `int` value
 * `gateway` - (Optional) give the IP you want to reserve for gateway, by default the first IP gets reserved for gateway
 

--- a/website/docs/r/network_view.html.markdown
+++ b/website/docs/r/network_view.html.markdown
@@ -9,17 +9,16 @@ description: |-
 
 Creates a network view in NIOS.
 
-This resource allows you to create network view in NIOS . When applied the network view will be created.
+This resource allows you to create network view in NIOS. When applied the network view will be created.
 
 
 ## Example Usage
+Creates a network view and links the network view to a tenant.
+```terraform
 
-```hcl
-# Creates a network view and links the network view to a tenant.
-
-resource "infoblox_network_view" "demo_network_view"{
-  network_view_name="demo1"
-  tenant_id="test"
+resource "infoblox_network_view" "demo_network_view" {
+  network_view_name = "demo1"
+  tenant_id         = "test"
 }
 ```
 ## Argument Reference

--- a/website/docs/r/ptr_record.html.markdown
+++ b/website/docs/r/ptr_record.html.markdown
@@ -10,20 +10,19 @@ description: |-
 
 Creates an PTR record in NIOS .
 
-When applied, PTR Record will be created in NIOS
+When applied, a PTR Record will be created in NIOS
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "infoblox_ptr_record" "demo_record"{
-
-  network_view_name="demo1"
-  vm_name="test"
-  cidr="10.0.0.0/24"
-  ip_addr="10.0.0.1" //use the ip address used in IP allocation
-  dns_view="default"
-  zone="$reverse_mappinf_zone"
-tenant_id="test"
+  network_view_name = "demo1"
+  vm_name           = "test"
+  cidr              = "10.0.0.0/24"
+  ip_addr           = "10.0.0.1"
+  dns_view          = "default"
+  zone              = "$reverse_mappinf_zone"
+  tenant_id         = "test"
 }
 ```
 ## Argument Reference
@@ -34,7 +33,7 @@ The following arguments are supported:
 * `vm_name` - (Required) A name you want to associate with the IP address.
 * `vm_id` - (Optional) Updates the VM id of the vm used to provision
 * `cidr` - (Required) The network block in cidr format
-* `tenant_id` - (Required) Links the network  to a tenant
+* `tenant_id` - (Required) Links the network  to a tenant. For on-premise solutions, this can be any value.
 * `dns_view` - (Optional) The view which contains the details of the zone. If not provided , record will be created under default view
 * `zone` - (Required) The zone in which you want to update a host record
 * `ip_addr` - (Required) - The IP address you want to update in NIOS. Use the Same IP you have passed during IP allocation.


### PR DESCRIPTION
Add proper spacing to examples and fix grammatical errors in documentation