### PR TITLE
updating the doc for developing and using the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,44 @@
+ <a href="https://www.infoblox.com">
+    <img src="https://avatars.githubusercontent.com/u/8064882?s=400&u=3b245589302c409aff2ce2ba26d95e6df6cfe342&v=4" alt="Infoblox logo" title="Infoblox" align="right" height="50" />
+</a> 
+ 
 # Terraform Provider for Infoblox
- <img width="171" alt="capture" src="https://user-images.githubusercontent.com/36291746/39614422-6b653088-4f8d-11e8-83fd-05b18ca974a2.PNG">
+Terraform provider plugin to integrate with Infoblox Network Identity Operating System [NIOS].
+The plugin enables lifecycle management of Infoblox NIOS DDI resources.
 
+The latest version of Infoblox NIOS provider is [v1.1.1](https://github.com/infobloxopen/terraform-provider-infoblox/releases/tag/v1.1.1)
+The features in development are available at [`develop`](https://github.com/infobloxopen/terraform-provider-infoblox/tree/develop) branch.
 
-## Build Status
-| Master                                                                                                                                                               | Develop                                                                                                                                                              |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![Build Status](https://travis-ci.org/infobloxopen/terraform-provider-infoblox.svg?branch=master)](https://travis-ci.org/infobloxopen/terraform-provider-infoblox)  | [![Build Status](https://travis-ci.org/infobloxopen/terraform-provider-infoblox.svg?branch=develop)](https://travis-ci.org/infobloxopen/terraform-provider-infoblox) |
-
-## Requirements
-* [Terraform](https://www.terraform.io/downloads.html) 0.11.x or greater
-* [Go](https://golang.org/doc/install) 1.12.x (to build the provider plugin)
-* CNA License need to be installed on NIOS. If CNA is not installed then following default EA's should be added in NIOS side:
-   * VM Name :: String Type
-   * VM ID :: String Type
+## NIOS Requirements
+CNA License need to be installed on NIOS. If CNA is not installed then following default EA's should be added in NIOS side manually:
    * Tenant ID :: String Type
    * CMP Type :: String Type
    * Cloud API Owned :: List Type (Values True, False)
    * Network Name :: String Type
+   * VM Name :: String Type
+   * VM ID :: String Type
 
-## Building the Provider
+## Quick Starts
+- [Using the provider](docs/USING.md)
+- [Developing the provider](docs/DEVELOPMENT.md)
 
-```sh
-$ git clone https://github.com/infobloxopen/terraform-provider-infoblox
-$ cd terraform-provider-infoblox
-$ make build
-```
+## Documentation
+The comprehensive documentation of plugin is available at Terraform registry.
 
-## Using the Provider
-If you're building the provider, follow the instructions to [install it as a plugin](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin). After the build is complete, copy the `terraform-provider-infoblox` binary into the same path as your terraform binary. After placing it into your plugins directory, run `terraform init` to initialize it.
+https://registry.terraform.io/providers/infobloxopen/infoblox/latest/docs
 
-## Developing the Provider
-If you wish to work on the provider, you'll first need Go installed on your machine (version 1.12+ is required).
-
-To compile the provider, run the following steps:
-```sh
-$ make build
-...
-$ ./terraform-provider-infoblox
-...
-```
-To test the provider, you can simply run `make test`.
-```sh
-$ make test
-```
-
-In order to run the full suite of acceptance tests `make testacc`.
-```sh
-$ make testacc
-```
-## Features of Provider
+## Provider features
+Provider has NIOS DDI resources as Terraform resources and datasources. Below is the consolidated list of the same.
 ### Resource
-* Creation of Network View in NIOS appliance
-* Creation & Deletion of Network in NIOS appliance
+* Network View
+* Network
 * Allocation & Deallocation of IP from a Network
 * Association & Disassociation of IP Address for a VM
-* Creation and Deletion of A, CNAME, Host, and Ptr records
+* A Record
+* PTR Record
+* CNAME Record
 
 ### Data Source
-* Supports Data Source for Network
-
-## Disclaimer
-To use the provider for DNS purposes, a parent (i.e. zone) must already exist. The plugin does not support the creation of zones.
-while running acceptance tests create a 10.0.0.0/24 network under default network view and create a reservation for 10.0.0.2 IP
+* Network
+* A Record
+* CNAME Record

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Terraform provider plugin to integrate with Infoblox Network Identity Operating 
 The plugin enables lifecycle management of Infoblox NIOS DDI resources.
 
 The latest version of Infoblox NIOS provider is [v1.1.1](https://github.com/infobloxopen/terraform-provider-infoblox/releases/tag/v1.1.1)
+
 The features in development are available at [`develop`](https://github.com/infobloxopen/terraform-provider-infoblox/tree/develop) branch.
 
 ## NIOS Requirements
-CNA License need to be installed on NIOS. If CNA is not installed then following default EA's should be added in NIOS side manually:
+A Cloud Network Automation [CNA] license needs to be installed on NIOS. If CNA is not installed then following default EAs must be added at the NIOS side manually:
    * Tenant ID :: String Type
    * CMP Type :: String Type
    * Cloud API Owned :: List Type (Values True, False)
@@ -18,7 +19,7 @@ CNA License need to be installed on NIOS. If CNA is not installed then following
    * VM Name :: String Type
    * VM ID :: String Type
 
-## Quick Starts
+## Quick Start
 - [Using the provider](docs/USING.md)
 - [Developing the provider](docs/DEVELOPMENT.md)
 
@@ -28,12 +29,12 @@ The comprehensive documentation of plugin is available at Terraform registry.
 https://registry.terraform.io/providers/infobloxopen/infoblox/latest/docs
 
 ## Provider features
-Provider has NIOS DDI resources as Terraform resources and datasources. Below is the consolidated list of the same.
+The provider has NIOS DDI resources as Terraform resources and datasources. Below is the consolidated list of supported resources and data sources:
 ### Resource
 * Network View
 * Network
-* Allocation & Deallocation of IP from a Network
-* Association & Disassociation of IP Address for a VM
+* Allocation & deallocation of an IP address from a Network
+* Association & disassociation of IP Address for a VM
 * A Record
 * PTR Record
 * CNAME Record

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,43 @@
+# Developing the provider
+Contribution to the plugin can be done at various levels and we would embrace it.
+Working at code level would require to setup the environment, clone the code, build and test the code.
+
+
+## Requirements
+Golang and Terraform in the system are basic requirements to build and test the plugin.
+* Install and configure apt version of [Golang](https://golang.org/doc/install). At this point 1.12.x version has been used for development.
+* [Terraform](https://www.terraform.io/downloads.html) 0.11.x used for development and testing.
+
+## Building the Provider
+Once environment has been setup we are ready to clone the code and build it. Run the build before and after the changes and make sure it passes without failures.
+
+The project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH).
+```sh
+$ mkdir -p $HOME/development/infoblox/
+$ cd $HOME/development/infoblox/
+$ git clone https://github.com/infobloxopen/terraform-provider-infoblox
+$ cd terraform-provider-infoblox
+$ make build
+```
+
+
+## Testing the provider
+To test the provider and to run the full suite of acceptance tests run below commands respectively,
+```sh
+$ make test
+$ make testacc
+```
+While running acceptance tests, 
+* Create appropriate DNS views and zones being defined in test files.
+* Create appropriate EAs
+
+Writing acceptance tests for the bugs fixed/features developed would be recommended.
+
+## Using the Provider
+The bug fixes and features developed can be tested using the binary built after source code changes.
+
+When `terraform init` is run on terraform v0.11 it creates a `.terraform` directory, in the parent directory. The newly created directory consists of plugin binaries specified in tf files. Replace the infoblox binary in this directory with the one you have built with the changes.
+
+The location of binary would be as below, when infoblox plugin version given is 1.1.0 ,
+`.terraform/plugins/registry.terraform.io/terraform-providers/infoblox/1.1.0/linux_amd64/`
+

--- a/docs/USING.md
+++ b/docs/USING.md
@@ -1,0 +1,24 @@
+# Using the Provider from Terraform Registry
+The plugin has been published under Terraform registry. Users can install it through terraform, for lifecycle management of Infoblox NIOS DDI objects.
+
+To use the published plugin,
+* Specify the version of the plugin and
+* Configure it with the proper credentials
+Terraform would take care to install the specified version of plugin when a `terraform init` is run.
+
+
+## Using it in Terraform v0.11
+The version of plugin and required credentials can be provided as follows in the tf file.
+```
+provider "infoblox"{
+  version="~> 1.0"
+  username="infoblox_user"
+  password="infoblox"
+  server="nios_server"
+}
+```
+* `version`     : plugin version published in the registry.
+* `username`    : NIOS grid user name
+* `password`    : NIOS grid user password
+* `server`      : NIOS rrid master or CP member IP address
+


### PR DESCRIPTION
To make the things simple for users and developers, have made bit of restructuring of existing README.md file content.
 
Added 2 independent sections as DEVELOPMENT and USING and they will be added as new files under doc folder. A reference of these sections would be provided from README.
 
Since the development and validation of existing content in GitHub repo was done with Golang v1.12.x and Terraform v0.11.x the content has been aligned to that.
 
