### PR TITLE
Field name change

### DIFF
--- a/examples/v0.14/A-record/infoblox.tf
+++ b/examples/v0.14/A-record/infoblox.tf
@@ -3,7 +3,7 @@ resource "infoblox_a_record" "a_record_static1"{
   ip_addr = "192.168.31.31"
   ttl = 10
   comment = "static A-record #1"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Location" = "New York"
     "Site" = "HQ"
   })

--- a/examples/v0.14/A-record/locals.tf
+++ b/examples/v0.14/A-record/locals.tf
@@ -1,8 +1,1 @@
-locals {
-    res_prefix = "terraform_example1"
-    tenant_id = "${local.res_prefix}_tenant"
-
-    # net_view = "default"
-    # ... or (as a non-standard example)
-    net_view = "${local.res_prefix}_netview"
-}
+../locals.tf

--- a/examples/v0.14/A-record/terraform.tf
+++ b/examples/v0.14/A-record/terraform.tf
@@ -1,13 +1,1 @@
-terraform {
-  # Required providers block for Terraform v0.14
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.50.0"
-    }
-    infoblox = {
-      source  = "terraform-providers/infoblox"
-      version = "~> 1.1.0"
-    }
-  }
-}
+../terraform.tf

--- a/examples/v0.14/AAAARecord/infoblox.tf
+++ b/examples/v0.14/AAAARecord/infoblox.tf
@@ -15,7 +15,7 @@ terraform {
 
 # Create record using an IPv6 Address
 resource "infoblox_aaaa_record" "aaaa_record_1" {
-  network_view_name = "default" 
+  network_view = "default"
   dns_view="default"            
 
   ipv6_addr="2000:01"           # "2000::/64" network MUST exist at NIOS
@@ -23,7 +23,7 @@ resource "infoblox_aaaa_record" "aaaa_record_1" {
   ttl = 3600
 
   comment = "AAAA record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -34,14 +34,14 @@ resource "infoblox_aaaa_record" "aaaa_record_1" {
 
 # Create record using an IPv6 CIDR
 resource "infoblox_aaaa_record" "aaaa_record_2" {
-  network_view_name = "non_default" # non_default network view MUST exist at NIOS
+  network_view = "non_default" # non_default network view MUST exist at NIOS
   dns_view="non_default"            # non_default network view MUST exist at NIOS
   cidr = "2000::/64"                # "2000::/64" network MUST exist at NIOS
   fqdn="aaaa_record.aws.com"        # "aws.com" zone MUST exist at NIOS
   ttl = 3600
 
   comment = "AAAA record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"

--- a/examples/v0.14/AWS/AllocationAndAssociation/infoblox.tf
+++ b/examples/v0.14/AWS/AllocationAndAssociation/infoblox.tf
@@ -14,11 +14,11 @@ terraform {
 
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.cidr_block
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -26,11 +26,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.ipv6_cidr_block
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -40,14 +40,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     Location = "Test loc."
@@ -56,14 +56,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     Location = "Test loc."
@@ -74,7 +74,7 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 
 # Allocate IP from network
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   host_name = "test"
 
@@ -85,7 +85,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   #enable_dhcp = "false"
   
   comment = "tf IPv4 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "VM Name" =  "tf-ec2-instance"
@@ -95,7 +95,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
 }
 
 resource "infoblox_ipv6_allocation" "ipv6_allocation" {
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
   host_name = "test"
@@ -107,7 +107,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   #enable_dhcp = "false"
 
   comment = "tf IPv6 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance-ipv6"
@@ -119,7 +119,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
 
 # Update Grid with VM data
 resource "infoblox_ipv4_association" "ipv4_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = aws_network_interface.ni.mac_address
@@ -132,7 +132,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance"
@@ -143,7 +143,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
 }
 
 resource "infoblox_ipv6_association" "ipv6_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = aws_network_interface.ni.mac_address
@@ -156,7 +156,7 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv6 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance-ipv6"

--- a/examples/v0.14/AWS/Network/infoblox.tf
+++ b/examples/v0.14/AWS/Network/infoblox.tf
@@ -14,11 +14,11 @@ terraform {
 
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.cidr_block
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -26,11 +26,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.ipv6_cidr_block
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -40,14 +40,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "Location" = "Test loc."
@@ -56,14 +56,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "Location" = "Test loc."

--- a/examples/v0.14/AWS/NetworkContainer/infoblox.tf
+++ b/examples/v0.14/AWS/NetworkContainer/infoblox.tf
@@ -14,10 +14,10 @@ terraform {
 
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
   cidr = aws_vpc.vpc.cidr_block
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -25,10 +25,10 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
   cidr = aws_vpc.vpc.ipv6_cidr_block
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"

--- a/examples/v0.14/AWS/NextAvailableNetwork/infoblox.tf
+++ b/examples/v0.14/AWS/NextAvailableNetwork/infoblox.tf
@@ -14,11 +14,11 @@ terraform {
 
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.cidr_block
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -26,11 +26,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.ipv6_cidr_block
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -40,14 +40,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "Location" = "Test loc."
@@ -56,14 +56,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "Location" = "Test loc."

--- a/examples/v0.14/AWS/PTRRecord/infoblox.tf
+++ b/examples/v0.14/AWS/PTRRecord/infoblox.tf
@@ -14,11 +14,11 @@ terraform {
 
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.cidr_block
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -28,11 +28,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = aws_vpc.vpc.ipv6_cidr_block
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -44,14 +44,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -62,14 +62,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -82,7 +82,7 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 
 # Allocate IP from network
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   host_name = "test"
 
@@ -93,7 +93,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   #enable_dhcp = "false"
   
   comment = "tf IPv4 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -105,7 +105,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
 }
 
 resource "infoblox_ipv6_allocation" "ipv6_allocation" {
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
   host_name = "test"
@@ -117,7 +117,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   #enable_dhcp = "false"
 
   comment = "tf IPv6 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -131,7 +131,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
 
 # Update Grid with VM data
 resource "infoblox_ipv4_association" "ipv4_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = aws_network_interface.ni.mac_address
@@ -144,7 +144,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -157,7 +157,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
 }
 
 resource "infoblox_ipv6_association" "ipv6_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = aws_network_interface.ni.mac_address
@@ -170,7 +170,7 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv6 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -191,14 +191,14 @@ resource "infoblox_ptr_record" "ib_ptr_record"{
   record_name = "tf-ec2-instance-ipv4.aws.com"
 
   # Record in reverse mapping zone
-  #network_view_name = "default"
+  #network_view = "default"
   #cidr = infoblox_ipv4_network.ipv4_network.cidr
   #ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
 
   ttl = 3600
 
   comment = "PTR record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"

--- a/examples/v0.14/AWS/README.md
+++ b/examples/v0.14/AWS/README.md
@@ -14,10 +14,13 @@ Install AWS CLI. Use AWS Configure command to configure Access Key ID and Secret
 - Network              : Create IPv4/IPv6 Network
 - NextAvailableNetwork : Get next available network from a given parent CIDR of a prefix length.
 - AllocationAndAssociation : Assign an IPv4 and IPv6 address to an AWS instance and get its MAC address synced at NIOS
+- PTRRecord            : Create PTR record in forward/reverse mapping zones 
+- CNAMERecord          : Create CNAME record in a zone
 
 ### Note
 ```
 A parent network container has to be in existence before requesting next available network from it.
+A forward/reverse mapping zone has to be in existence for a PTR record creation.
 ```
 
 # Running the Resource

--- a/examples/v0.14/Azure/NetworkContainer/IPv4/infoblox.tf
+++ b/examples/v0.14/Azure/NetworkContainer/IPv4/infoblox.tf
@@ -1,13 +1,13 @@
 resource "infoblox_network_view" "nv1" {
   tenant_id = local.tenant_id
-  network_view_name=local.net_view
+  network_view=local.net_view
 }
 
 resource "infoblox_ipv4_network_container" "v4nc_1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = "10.0.0.0/16"
   comment = "new network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Location" = "Test loc."
     "Site" = "Test site"
     "Tenant ID" = local.tenant_id
@@ -15,18 +15,18 @@ resource "infoblox_ipv4_network_container" "v4nc_1" {
 }
 
 resource "infoblox_ipv4_network" "subnet1"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   allocate_prefix_len = 24
   parent_cidr = infoblox_ipv4_network_container.v4nc_1.cidr
   reserve_ip=3
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Network Name" = "${local.res_prefix}_subnet1"
   })
 }
 
 resource "infoblox_ipv4_allocation" "alloc1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet1.cidr
   host_name = "test"
 
@@ -36,7 +36,7 @@ resource "infoblox_ipv4_allocation" "alloc1" {
   #enable_dns = "false"
   #enable_dhcp = "false"  
   
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "VM Name" = "${local.res_prefix}_vm1"
   })

--- a/examples/v0.14/Azure/NetworkContainer/IPv6/infoblox.tf
+++ b/examples/v0.14/Azure/NetworkContainer/IPv6/infoblox.tf
@@ -1,14 +1,14 @@
 resource "infoblox_network_view" "nv1" {
   tenant_id = local.tenant_id
-  network_view_name=local.net_view
+  network_view=local.net_view
 }
 
 resource "infoblox_ipv4_network_container" "nc_1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = "10.0.0.0/16"
   comment = "new network container"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -16,19 +16,19 @@ resource "infoblox_ipv4_network_container" "nc_1" {
 }
 
 resource "infoblox_ipv4_network" "subnet1"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   allocate_prefix_len = 24
   parent_cidr = infoblox_ipv4_network_container.nc_1.cidr
   reserve_ip=3
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Network Name" = "${local.res_prefix}_subnet1"
   })
 }
 
 resource "infoblox_ipv4_allocation" "alloc1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet1.cidr
 
   #Create Host Record with DNS and DHCP flags
@@ -37,13 +37,13 @@ resource "infoblox_ipv4_allocation" "alloc1" {
   #enable_dns = "false"
   #enable_dhcp = "false"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
   })
 }
 
 resource "infoblox_ipv4_association" "assoc1"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = infoblox_ipv4_allocation.alloc1.cidr
   mac_addr = local.vm_mac_addr
   ip_addr = infoblox_ipv4_allocation.alloc1.ip_addr
@@ -54,7 +54,7 @@ resource "infoblox_ipv4_association" "assoc1"{
   #enable_dns = "false"
   #enable_dhcp = "false"  
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "VM Name" = "${local.res_prefix}_vm1"
     "VM ID" = local.vm_id
@@ -62,11 +62,11 @@ resource "infoblox_ipv4_association" "assoc1"{
 }
 
 resource "infoblox_ipv6_network_container" "nc_2" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = "fc00::/56"
   comment = "new network container"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -74,13 +74,13 @@ resource "infoblox_ipv6_network_container" "nc_2" {
 }
 
 resource "infoblox_ipv6_network" "subnet2"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   allocate_prefix_len = 64
   parent_cidr = infoblox_ipv6_network_container.nc_2.cidr
   reserve_ip=10
 
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Network Name" = "${local.res_prefix}_subnet2"
   })
@@ -93,7 +93,7 @@ locals {
 resource "infoblox_ipv6_allocation" "alloc_reserved" {
   count=local.ipv6_reserved_ips
 
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv6_network.subnet2.cidr
   duid = format("00:%.2x", count.index)
 
@@ -103,13 +103,13 @@ resource "infoblox_ipv6_allocation" "alloc_reserved" {
   #enable_dns = "false"
   #enable_dhcp = "false"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
   })
 }
 
 resource "infoblox_ipv6_allocation" "alloc2" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv6_network.subnet2.cidr
   duid = format("00:%.2x", local.ipv6_reserved_ips)
 
@@ -119,7 +119,7 @@ resource "infoblox_ipv6_allocation" "alloc2" {
   #enable_dns = "false"
   #enable_dhcp = "false"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
   })
 
@@ -127,7 +127,7 @@ resource "infoblox_ipv6_allocation" "alloc2" {
 }
 
 resource "infoblox_ipv6_association" "assoc2"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = infoblox_ipv6_allocation.alloc2.cidr
   mac_addr = local.vm_mac_addr
   ip_addr = infoblox_ipv6_allocation.alloc2.ip_addr
@@ -139,7 +139,7 @@ resource "infoblox_ipv6_association" "assoc2"{
   #enable_dns = "false"
   #enable_dhcp = "false"
   
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "VM Name" = "${local.res_prefix}_vm1"
     "VM ID" = local.vm_id

--- a/examples/v0.14/Azure/NextAvailableNetwork/infoblox.tf
+++ b/examples/v0.14/Azure/NextAvailableNetwork/infoblox.tf
@@ -1,14 +1,14 @@
 resource "infoblox_network_view" "nv1" {
   tenant_id = local.tenant_id
-  network_view_name=local.net_view
+  network_view=local.net_view
 }
 
 resource "infoblox_ipv4_network_container" "v4nc_1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr = "10.0.0.0/16"
   comment = "new network container"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Location" = "Test loc."
     "Site" = "Test site"
     "Tenant ID" = local.tenant_id
@@ -16,12 +16,12 @@ resource "infoblox_ipv4_network_container" "v4nc_1" {
 }
 
 resource "infoblox_ipv4_network" "subnet1"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   allocate_prefix_len = 24
   parent_cidr = infoblox_ipv4_network_container.v4nc_1.cidr
   reserve_ip=3
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Network Name" = "${local.res_prefix}_subnet1"
     "TestEA1" = "text3"
@@ -30,12 +30,12 @@ resource "infoblox_ipv4_network" "subnet1"{
 }
 
 resource "infoblox_ipv4_network" "subnet2"{
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   allocate_prefix_len = 24
   parent_cidr = infoblox_ipv4_network_container.v4nc_1.cidr
   reserve_ip=3
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "Network Name" = "${local.res_prefix}_subnet2"
     Location = "Test loc."
@@ -46,7 +46,7 @@ resource "infoblox_ipv4_network" "subnet2"{
 }
 
 resource "infoblox_ipv4_allocation" "alloc1" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet1.cidr
 
   #Create Host Record with DNS and DHCP flags
@@ -55,14 +55,14 @@ resource "infoblox_ipv4_allocation" "alloc1" {
   #enable_dns = "false"
   #enable_dhcp = "false"  
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "VM Name" = "${local.res_prefix}_vm1"
   })
 }
 
 resource "infoblox_ipv4_allocation" "alloc2" {
-  network_view_name=infoblox_network_view.nv1.network_view_name
+  network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet2.cidr
   host_name = "test"
 
@@ -72,7 +72,7 @@ resource "infoblox_ipv4_allocation" "alloc2" {
   #enable_dns = "false"
   #enable_dhcp = "false"
 
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = local.tenant_id
     "VM Name" = "${local.res_prefix}_vm1"
   })

--- a/examples/v0.14/CNAMERecord/infoblox.tf
+++ b/examples/v0.14/CNAMERecord/infoblox.tf
@@ -18,7 +18,7 @@ resource "infoblox_cname_record" "ib_cname_record"{
   ttl = 3600
 
   comment = "CNAME record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "CMP Type" = "Terraform"
     "Cloud API Owned" = "True"
@@ -26,4 +26,3 @@ resource "infoblox_cname_record" "ib_cname_record"{
     "Site" = "Test site"
   })
 }
-

--- a/examples/v0.14/README.md
+++ b/examples/v0.14/README.md
@@ -1,3 +1,4 @@
 
-* The Terraform configuration files under `v0.14` path are written and tested on Terraform v0.14 version and are actively maintained.
-* The terraform configuration files under `archived` directory are of older version and are not maintained actively.
+# While using IPv6 Features make sure to consider the following:
+* IPv6 Allocation and Association through Fixed Address/Host Record mandates unique DUID in .tf file.
+* For all the cloud providers(AWS, Azure and VMWare), DUID will be updated with MAC address of the interface in NIOS.

--- a/examples/v0.14/VMWare/AllocationAndAssociation/infoblox.tf
+++ b/examples/v0.14/VMWare/AllocationAndAssociation/infoblox.tf
@@ -1,10 +1,10 @@
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "10.0.0.0/16"
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -12,11 +12,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "2001:1890:1959:2710::/62"
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -25,14 +25,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     Location = "Test loc."
@@ -41,14 +41,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     Location = "Test loc."
@@ -58,7 +58,7 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 
 # Allocate IP from network
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   host_name = "test"
 
@@ -69,7 +69,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "VM Name" =  "tf-vmware-ipv4"
@@ -79,7 +79,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
 }
 
 resource "infoblox_ipv6_allocation" "ipv6_allocation" {
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
   host_name = "test"
@@ -91,7 +91,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   #enable_dhcp = "false"
 
   comment = "tf IPv6 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" = "tf-vmware-ipv6"
@@ -102,7 +102,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
 
 # Update Grid with VM data
 resource "infoblox_ipv4_association" "ipv4_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = vsphere_virtual_machine.vm_ipv4.network_interface[0].mac_address
@@ -115,7 +115,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" = vsphere_virtual_machine.vm_ipv4.name
@@ -126,7 +126,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
 }
 
 resource "infoblox_ipv6_association" "ipv6_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = vsphere_virtual_machine.vm_ipv6.network_interface[0].mac_address
@@ -139,7 +139,7 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv6 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  vsphere_virtual_machine.vm_ipv6.name

--- a/examples/v0.14/VMWare/Network/IPv4/infoblox.tf
+++ b/examples/v0.14/VMWare/Network/IPv4/infoblox.tf
@@ -1,13 +1,13 @@
 # Create a network in Infoblox Griby passing the CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     Location = "Test loc."

--- a/examples/v0.14/VMWare/Network/IPv6/infoblox.tf
+++ b/examples/v0.14/VMWare/Network/IPv6/infoblox.tf
@@ -1,13 +1,13 @@
 # Create an IPv6 Network in Infoblox Grid when CIDR is passed
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     Location = "Test loc."

--- a/examples/v0.14/VMWare/NetworkContainer/IPv4/infoblox.tf
+++ b/examples/v0.14/VMWare/NetworkContainer/IPv4/infoblox.tf
@@ -1,10 +1,10 @@
 # Create an IPv4 network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "10.0.0.0/16"
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"

--- a/examples/v0.14/VMWare/NetworkContainer/IPv6/infoblox.tf
+++ b/examples/v0.14/VMWare/NetworkContainer/IPv6/infoblox.tf
@@ -1,10 +1,10 @@
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "10.0.0.0/16"
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -12,11 +12,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "2001:1890:1959:2710::/62"
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -25,14 +25,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     Location = "Test loc."
@@ -41,14 +41,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     Location = "Test loc."

--- a/examples/v0.14/VMWare/NextAvailableNetwork/infoblox.tf
+++ b/examples/v0.14/VMWare/NextAvailableNetwork/infoblox.tf
@@ -1,10 +1,10 @@
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "10.0.0.0/16"
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -12,11 +12,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "2001:1890:1959:2710::/62"
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     Location = "Test loc."
     Site = "Test site"
@@ -25,14 +25,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     Location = "Test loc."
@@ -41,14 +41,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     Location = "Test loc."

--- a/examples/v0.14/VMWare/PTRRecord/infoblox.tf
+++ b/examples/v0.14/VMWare/PTRRecord/infoblox.tf
@@ -1,10 +1,10 @@
 # Create a network container in Infoblox Grid
 resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "10.0.0.0/16"
   comment = "tf IPv4 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -12,11 +12,11 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
 }
 
 resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
-  network_view_name="default"
+  network_view="default"
 
   cidr = "2001:1890:1959:2710::/62"
   comment = "tf IPv6 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Location" = "Test loc."
     "Site" = "Test site"
@@ -25,14 +25,14 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
 
 # Allocate a network in Infoblox Grid under provided parent CIDR
 resource "infoblox_ipv4_network" "ipv4_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv4_network_container.IPv4_nw_c.cidr
   allocate_prefix_len = 24
   reserve_ip = 2
 
   comment = "tf IPv4 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "Location" = "Test loc."
@@ -41,14 +41,14 @@ resource "infoblox_ipv4_network" "ipv4_network"{
 }
 
 resource "infoblox_ipv6_network" "ipv6_network"{
-  network_view_name = "default"
+  network_view = "default"
 
   parent_cidr = infoblox_ipv6_network_container.IPv6_nw_c.cidr
   allocate_prefix_len = 64
   reserve_ipv6 = 3
 
   comment = "tf IPv6 network"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "Location" = "Test loc."
@@ -58,7 +58,7 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 
 # Allocate IP from network
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   host_name = "test"
 
@@ -69,7 +69,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "VM Name" =  "tf-vmware-ipv4"
@@ -79,7 +79,7 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
 }
 
 resource "infoblox_ipv6_allocation" "ipv6_allocation" {
-  network_view_name= "default"
+  network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
   host_name = "test"
@@ -91,7 +91,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   #enable_dhcp = "false"
 
   comment = "tf IPv6 allocation"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" = "tf-vmware-ipv6"
@@ -102,7 +102,7 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
 
 # Update Grid with VM data
 resource "infoblox_ipv4_association" "ipv4_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = vsphere_virtual_machine.vm_ipv4.network_interface[0].mac_address
@@ -115,7 +115,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv4 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" = vsphere_virtual_machine.vm_ipv4.name
@@ -126,7 +126,7 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
 }
 
 resource "infoblox_ipv6_association" "ipv6_associate"{
-  network_view_name = "default"
+  network_view = "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = vsphere_virtual_machine.vm_ipv6.network_interface[0].mac_address
@@ -139,7 +139,7 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   #enable_dhcp = "false"
 
   comment = "tf IPv6 Association"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  vsphere_virtual_machine.vm_ipv6.name
@@ -158,12 +158,12 @@ resource "infoblox_ptr_record" "ib_ptr_record_ipv4" {
   record_name = "tf-vmware-ipv4.vmware.com"
 
   # Record in reverse mapping zone
-  #network_view_name = "default"
+  #network_view = "default"
   #cidr = infoblox_ipv4_network.ipv4_network.cidr
   #ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
 
   comment = "PTR record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  vsphere_virtual_machine.vm_ipv6.name
@@ -181,12 +181,12 @@ resource "infoblox_ptr_record" "ib_ptr_record_ipv6" {
   record_name = "tf-vmware-ipv6.vmware.com"
 
   # Record in reverse mapping zone
-  #network_view_name = "default"
+  #network_view = "default"
   #cidr = infoblox_ipv4_network.ipv4_network.cidr
   #ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
 
   comment = "PTR record created"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  vsphere_virtual_machine.vm_ipv6.name

--- a/infoblox/resource_infoblox_a_record.go
+++ b/infoblox/resource_infoblox_a_record.go
@@ -18,6 +18,7 @@ func resourceARecord() *schema.Resource {
 			"network_view": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:     "default",
 				Description: "Network view to use when allocating an IP address from a network dynamically. For static allocation, leave this field empty.",
 			},
 			"cidr": {
@@ -52,7 +53,7 @@ func resourceARecord() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the A-record.",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
@@ -91,11 +92,11 @@ func resourceARecordCreate(d *schema.ResourceData, m interface{}) error {
 
 	comment := d.Get("comment").(string)
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -116,11 +117,11 @@ func resourceARecordCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceARecordGet(d *schema.ResourceData, m interface{}) error {
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -144,6 +145,9 @@ func resourceARecordGet(d *schema.ResourceData, m interface{}) error {
 
 func resourceARecordUpdate(d *schema.ResourceData, m interface{}) error {
 	networkView := d.Get("network_view").(string)
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
+	}
 	cidr := d.Get("cidr").(string)
 	fqdn := d.Get("fqdn").(string)
 	ipAddr := d.Get("ip_addr").(string)
@@ -177,11 +181,11 @@ func resourceARecordUpdate(d *schema.ResourceData, m interface{}) error {
 
 	comment := d.Get("comment").(string)
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -203,11 +207,11 @@ func resourceARecordUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceARecordDelete(d *schema.ResourceData, m interface{}) error {
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string

--- a/infoblox/resource_infoblox_a_record_test.go
+++ b/infoblox/resource_infoblox_a_record_test.go
@@ -114,7 +114,7 @@ func TestAccResourceARecord(t *testing.T) {
 						ttl = 10
 						dns_view = "nondefault_view"
 						comment = "test comment 1"
-						extensible_attributes = jsonencode({
+						ext_attrs = jsonencode({
 						  "Location" = "New York"
 						  "Site" = "HQ"
 						})

--- a/infoblox/resource_infoblox_aaaa_record.go
+++ b/infoblox/resource_infoblox_aaaa_record.go
@@ -16,7 +16,7 @@ func resourceAAAARecord() *schema.Resource {
 		Delete: resourceAAAARecordDelete,
 
 		Schema: map[string]*schema.Schema{
-			"network_view_name": {
+			"network_view": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "default",
@@ -55,7 +55,7 @@ func resourceAAAARecord() *schema.Resource {
 				Optional:    true,
 				Description: "A description about AAAA record.",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
@@ -74,7 +74,7 @@ func setTFFieldsForRecordAAAA(d *schema.ResourceData, rec *ibclient.RecordAAAA) 
 
 func resourceAAAARecordCreate(d *schema.ResourceData, m interface{}) error {
 
-	networkView := d.Get("network_view_name").(string)
+	networkView := d.Get("network_view").(string)
 	cidr := d.Get("cidr").(string)
 	ipv6Addr := d.Get("ipv6_addr").(string)
 
@@ -82,11 +82,11 @@ func resourceAAAARecordCreate(d *schema.ResourceData, m interface{}) error {
 	fqdn := d.Get("fqdn").(string)
 
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -132,11 +132,11 @@ func resourceAAAARecordCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceAAAARecordGet(d *schema.ResourceData, m interface{}) error {
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -157,7 +157,10 @@ func resourceAAAARecordGet(d *schema.ResourceData, m interface{}) error {
 
 func resourceAAAARecordUpdate(d *schema.ResourceData, m interface{}) error {
 
-	networkView := d.Get("network_view_name").(string)
+	networkView := d.Get("network_view").(string)
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
+	}
 	cidr := d.Get("cidr").(string)
 	ipv6Addr := d.Get("ipv6_addr").(string)
 
@@ -178,11 +181,11 @@ func resourceAAAARecordUpdate(d *schema.ResourceData, m interface{}) error {
 	fqdn := d.Get("fqdn").(string)
 
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -225,11 +228,11 @@ func resourceAAAARecordDelete(d *schema.ResourceData, m interface{}) error {
 
 	dnsView := d.Get("dns_view").(string)
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 

--- a/infoblox/resource_infoblox_aaaa_record_test.go
+++ b/infoblox/resource_infoblox_aaaa_record_test.go
@@ -119,7 +119,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 						ttl = 155
 						dns_view = "default"
 						comment = "test comment 2"
-						extensible_attributes = jsonencode({
+						ext_attrs = jsonencode({
 							"Tenant ID"="terraform_test_tenant"
 							"Location"="Test loc"
 						})

--- a/infoblox/resource_infoblox_aaaa_record_test.go
+++ b/infoblox/resource_infoblox_aaaa_record_test.go
@@ -88,7 +88,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 						ipv6_addr = "2000::1"
 						dns_view = "default"
 						comment = "test comment 1"
-						extensible_attributes = jsonencode({
+						ext_attrs = jsonencode({
 							"Tenant ID"="terraform_test_tenant"
 							"Location"="Test loc"
 							"Site"="Test site"

--- a/infoblox/resource_infoblox_cname_record.go
+++ b/infoblox/resource_infoblox_cname_record.go
@@ -44,7 +44,7 @@ func resourceCNAMERecord() *schema.Resource {
 				Optional:    true,
 				Description: "A description about CNAME record.",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
@@ -60,11 +60,11 @@ func resourceCNAMERecordCreate(d *schema.ResourceData, m interface{}) error {
 	alias := d.Get("alias").(string)
 
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -97,11 +97,11 @@ func resourceCNAMERecordCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceCNAMERecordGet(d *schema.ResourceData, m interface{}) error {
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -130,11 +130,11 @@ func resourceCNAMERecordUpdate(d *schema.ResourceData, m interface{}) error {
 	alias := d.Get("alias").(string)
 
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -168,11 +168,11 @@ func resourceCNAMERecordUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceCNAMERecordDelete(d *schema.ResourceData, m interface{}) error {
 
 	dnsView := d.Get("dns_view").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 

--- a/infoblox/resource_infoblox_cname_record_test.go
+++ b/infoblox/resource_infoblox_cname_record_test.go
@@ -15,7 +15,7 @@ resource "infoblox_cname_record" "foo"{
 	canonical="test-canonicalName.a.com"
 	alias="test-aliasname.a.com"
 	comment="CNAME record created"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
 		"Location" = "Test loc"
 		"Site" = "Test site"
@@ -30,7 +30,7 @@ resource "infoblox_cname_record" "foo"{
 	canonical="test-canonicalName.a.com"
 	alias="test-aliasname.a.com"
 	comment="CNAME record updated"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
 		"Location" = "Test loc 2"
 		"Site" = "Test site 2"
@@ -93,11 +93,11 @@ func validateRecordCNAME(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && recCNAME.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && recCNAME.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil

--- a/infoblox/resource_infoblox_network.go
+++ b/infoblox/resource_infoblox_network.go
@@ -11,7 +11,7 @@ import (
 func resourceNetwork() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"network_view_name": {
+			"network_view": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "default",
@@ -57,7 +57,7 @@ func resourceNetwork() *schema.Resource {
 				Optional:    true,
 				Description: "A string describing the network",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
@@ -69,7 +69,7 @@ func resourceNetwork() *schema.Resource {
 
 func resourceNetworkCreate(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
 
-	networkViewName := d.Get("network_view_name").(string)
+	networkViewName := d.Get("network_view").(string)
 	parentCidr := d.Get("parent_cidr").(string)
 	prefixLen := d.Get("allocate_prefix_len").(int)
 	cidr := d.Get("cidr").(string)
@@ -78,11 +78,11 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}, isIPv6 bool) e
 	gateway := d.Get("gateway").(string)
 
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -160,12 +160,12 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}, isIPv6 bool) e
 }
 func resourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 
-	networkViewName := d.Get("network_view_name").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	networkViewName := d.Get("network_view").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -189,12 +189,15 @@ func resourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 }
 func resourceNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 
-	networkViewName := d.Get("network_view_name").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	networkViewName := d.Get("network_view").(string)
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
+	}
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -228,12 +231,12 @@ func resourceNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceNetworkDelete(d *schema.ResourceData, m interface{}) error {
-	networkViewName := d.Get("network_view_name").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	networkViewName := d.Get("network_view").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string

--- a/infoblox/resource_infoblox_network_container.go
+++ b/infoblox/resource_infoblox_network_container.go
@@ -11,7 +11,7 @@ import (
 func resourceNetworkContainer() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"network_view_name": {
+			"network_view": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of network view for the network container.",
@@ -27,7 +27,7 @@ func resourceNetworkContainer() *schema.Resource {
 				Optional:    true,
 				Description: "A description of the network container.",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
@@ -38,15 +38,15 @@ func resourceNetworkContainer() *schema.Resource {
 }
 
 func resourceNetworkContainerCreate(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
-	nvName := d.Get("network_view_name").(string)
+	nvName := d.Get("network_view").(string)
 	cidr := d.Get("cidr").(string)
 	comment := d.Get("comment").(string)
 
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -77,11 +77,11 @@ func resourceNetworkContainerCreate(d *schema.ResourceData, m interface{}, isIPv
 }
 
 func resourceNetworkContainerRead(d *schema.ResourceData, m interface{}) error {
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
@@ -103,13 +103,16 @@ func resourceNetworkContainerRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceNetworkContainerUpdate(d *schema.ResourceData, m interface{}) error {
-	nvName := d.Get("network_view_name").(string)
+	nvName := d.Get("network_view").(string)
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
+	}
 	cidr := d.Get("cidr").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 
@@ -146,11 +149,11 @@ func resourceNetworkContainerUpdate(d *schema.ResourceData, m interface{}) error
 }
 
 func resourceNetworkContainerDelete(d *schema.ResourceData, m interface{}) error {
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string

--- a/infoblox/resource_infoblox_network_container_test.go
+++ b/infoblox/resource_infoblox_network_container_test.go
@@ -12,10 +12,10 @@ import (
 
 var resCfgNetworkContainer_create_ipv4 = fmt.Sprintf(`
 resource "infoblox_ipv4_network_container" "nc_1" {
-  network_view_name = "%s"
+  network_view = "%s"
   cidr = "10.0.0.0/16"
   comment = "10.0.0.0/16 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
 	"Tenant ID" = "terraform_test_tenant"
     Location = "Test loc."
     Site = "Test site"
@@ -26,10 +26,10 @@ resource "infoblox_ipv4_network_container" "nc_1" {
 
 var resCfgNetworkContainer_update_ipv4 = fmt.Sprintf(`
 resource "infoblox_ipv4_network_container" "nc_1" {
-  network_view_name = "%s"
+  network_view = "%s"
   cidr = "10.0.0.0/16"
   comment = "new 10.0.0.0/16 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
 	"Tenant ID" = "terraform_test_tenant"
     Location = "Test loc. 2"
     TestEA1 = "text3"
@@ -39,20 +39,20 @@ resource "infoblox_ipv4_network_container" "nc_1" {
 
 var resCfgNetworkContainer_update2_ipv4 = fmt.Sprintf(`
 resource "infoblox_ipv4_network_container" "nc_1" {
-  network_view_name = "%s"
+  network_view = "%s"
   cidr = "10.0.0.0/16"
   comment = ""
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
 	"Tenant ID" = "terraform_test_tenant"
   })
 }`, testNetView)
 
 var resCfgNetworkContainer_create_ipv6 = fmt.Sprintf(`
 resource "infoblox_ipv6_network_container" "nc_1" {
-  network_view_name = "%s"
+  network_view = "%s"
   cidr = "fc00::/56"
   comment = "fc00::/56 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
 	"Tenant ID" = "terraform_test_tenant"
     Location = "Test loc."
     Site = "Test site"
@@ -63,10 +63,10 @@ resource "infoblox_ipv6_network_container" "nc_1" {
 
 var resCfgNetworkContainer_update_ipv6 = fmt.Sprintf(`
 resource "infoblox_ipv6_network_container" "nc_1" {
-  network_view_name = "%s"
+  network_view = "%s"
   cidr = "fc00::/56"
   comment = "new comment for fc00::/56 network container"
-  extensible_attributes = jsonencode({
+  ext_attrs = jsonencode({
 	"Tenant ID" = "terraform_test_tenant"
     Location = "Test loc. 2"
     TestEA1 = ["text3"]
@@ -107,7 +107,7 @@ func validateNetworkContainer(
 		expNv := expectedValue.NetviewName
 		if nc.NetviewName != expNv {
 			return fmt.Errorf(
-				"the value of 'network_view_name' field is '%s', but expected '%s'",
+				"the value of 'network_view' field is '%s', but expected '%s'",
 				nc.NetviewName, expNv)
 		}
 
@@ -129,11 +129,11 @@ func validateNetworkContainer(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && nc.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && nc.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil

--- a/infoblox/resource_infoblox_network_test.go
+++ b/infoblox/resource_infoblox_network_test.go
@@ -11,10 +11,10 @@ import (
 
 var testAccresourceIPv4NetworkCreate = fmt.Sprintf(`
 resource "infoblox_ipv4_network" "foo"{
-	network_view_name="default"
+	network_view="default"
 	cidr="10.10.0.0/24"
 	comment = "10.0.0.0/24 network created"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Network Name"= "demo-network"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc."
@@ -26,10 +26,10 @@ resource "infoblox_ipv4_network" "foo"{
 
 var testAccresourceIPv4NetworkUpdate = fmt.Sprintf(`
 resource "infoblox_ipv4_network" "foo"{
-	network_view_name="default"
+	network_view="default"
 	cidr="10.10.0.0/24"
 	comment = "10.0.0.0/24 network updated"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Network Name"= "demo-network"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc. 2"
@@ -41,10 +41,10 @@ resource "infoblox_ipv4_network" "foo"{
 
 var testAccresourceIPv6NetworkCreate = fmt.Sprintf(`
 	resource "infoblox_ipv6_network" "foo"{
-		network_view_name="default"
+		network_view="default"
 		cidr="2001:db8:abcd:12::/64"
 		comment = "2001:db8:abcd:12::/64 network created"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"Tenant ID" = "terraform_test_tenant"
 			"Network Name"= "demo-network"
 			Location = "Test loc."
@@ -56,10 +56,10 @@ var testAccresourceIPv6NetworkCreate = fmt.Sprintf(`
 
 var testAccresourceIPv6NetworkUpdate = fmt.Sprintf(`
 	resource "infoblox_ipv6_network" "foo"{
-		network_view_name="default"
+		network_view="default"
 		cidr="2001:db8:abcd:12::/64"
 		comment = "2001:db8:abcd:12::/64 network updated"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"Tenant ID" = "terraform_test_tenant"
 			"Network Name"= "demo-network"
 			Location = "Test loc. 2"
@@ -100,7 +100,7 @@ func validateNetwork(
 		expNv := expectedValue.NetviewName
 		if nw.NetviewName != expNv {
 			return fmt.Errorf(
-				"the value of 'network_view_name' field is '%s', but expected '%s'",
+				"the value of 'network_view' field is '%s', but expected '%s'",
 				nw.NetviewName, expNv)
 		}
 
@@ -115,11 +115,11 @@ func validateNetwork(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && nw.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && nw.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil


### PR DESCRIPTION
- Changed the field names network_view_name and extensible_attributes to network_view and ext_attrs respectively to meet WAPI standards.
- Added a "default" value for the network_view field of A-record resource.