### PR TITLE
Fix TTL and Update functions

### DIFF
--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -1,11 +1,17 @@
 package infoblox
 
 import (
+	"math"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	ibclient "github.com/infobloxopen/infoblox-go-client"
+)
+
+// Common parameters
+const (
+	ttlUndef = math.MinInt32
 )
 
 //Provider returns a terraform.ResourceProvider.

--- a/infoblox/resource_infoblox_cname_record.go
+++ b/infoblox/resource_infoblox_cname_record.go
@@ -35,7 +35,7 @@ func resourceCNAMERecord() *schema.Resource {
 			"ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     0,
+				Default:     ttlUndef,
 				Description: "TTL attribute value for the record.",
 			},
 			"comment": {
@@ -69,13 +69,14 @@ func resourceCNAMERecordCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	var ttl uint32
-	tempVal, useTtl := d.GetOk("ttl")
-	if useTtl {
-		tempTtl := tempVal.(int)
-		if tempTtl < 0 {
-			return fmt.Errorf("TTL value must be 0 or higher")
-		}
-		ttl = uint32(tempTtl)
+	useTtl := false
+	tempVal := d.Get("ttl")
+	tempTTL := tempVal.(int)
+	if tempTTL >= 0 {
+		useTtl = true
+		ttl = uint32(tempTTL)
+	} else if tempTTL != ttlUndef {
+		return fmt.Errorf("TTL value must be 0 or higher")
 	}
 
 	var tenantID string
@@ -139,13 +140,14 @@ func resourceCNAMERecordUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	var ttl uint32
-	tempVal, useTtl := d.GetOk("ttl")
-	if useTtl {
-		tempTtl := tempVal.(int)
-		if tempTtl < 0 {
-			return fmt.Errorf("TTL value must be 0 or higher")
-		}
-		ttl = uint32(tempTtl)
+	useTtl := false
+	tempVal := d.Get("ttl")
+	tempTTL := tempVal.(int)
+	if tempTTL >= 0 {
+		useTtl = true
+		ttl = uint32(tempTTL)
+	} else if tempTTL != ttlUndef {
+		return fmt.Errorf("TTL value must be 0 or higher")
 	}
 
 	var tenantID string

--- a/infoblox/resource_infoblox_ptr_record_test.go
+++ b/infoblox/resource_infoblox_ptr_record_test.go
@@ -15,7 +15,7 @@ resource "infoblox_ptr_record" "foo"{
 	ptrdname="testPtrdName.a.com"
 	record_name="testName.a.com"
 	comment="PTR record created in forward mapping zone"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
 		"Location" = "Test loc"
 		"Site" = "Test site"
@@ -25,12 +25,12 @@ resource "infoblox_ptr_record" "foo"{
 
 var testAccresourceRecordPTRCreate_2 = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo2"{
-	network_view_name="default"
+	network_view="default"
     dns_view="default"
 	ptrdname="testPtrdName2.a.com"
 	ip_addr = "10.0.0.2"
 	comment="PTR record created in reverse mapping zone with IP"
-	extensible_attributes=jsonencode({
+	ext_attrs=jsonencode({
 		"Tenant ID"="terraform_test_tenant"
 		"Location"="Test loc."
 		"Site"="Test site"
@@ -44,7 +44,7 @@ resource "infoblox_ptr_record" "foo"{
 	ptrdname="testPtrdName.a.com"
 	record_name="testName.a.com"
 	comment="PTR record updated in forward mapping zone"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
 		"Location" = "Test loc"
 		"Site" = "Test site"
@@ -54,12 +54,12 @@ resource "infoblox_ptr_record" "foo"{
 
 var testAccresourceRecordPTRUpdate_2 = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo2"{
-	network_view_name = "default"
+	network_view = "default"
 	dns_view="default"
 	ptrdname="testPtrdName2.a.com"
 	ip_addr = "10.0.0.2"
 	comment="PTR record created in reverse mapping zone with IP"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"Tenant ID"="terraform_test_tenant"
 		"Location"="Test loc."
 		"Site"="Test site"
@@ -113,11 +113,11 @@ func validateRecordPTR(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && recPtr.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && recPtr.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil

--- a/vendor/github.com/infobloxopen/infoblox-go-client/objects.go
+++ b/vendor/github.com/infobloxopen/infoblox-go-client/objects.go
@@ -429,8 +429,8 @@ type RecordA struct {
 	Name     string `json:"name,omitempty"`
 	View     string `json:"view,omitempty"`
 	Zone     string `json:"zone,omitempty"`
-	TTL      uint32 `json:"ttl"`
-	UseTTL   bool   `json:"use_ttl"`
+	UseTtl   bool   `json:"use_ttl"`
+	Ttl      uint32 `json:"ttl"`
 	Comment  string `json:"comment"`
 	Ea       EA     `json:"extattrs"`
 }
@@ -460,8 +460,8 @@ func NewRecordA(
 	res.Zone = zone
 	res.Name = name
 	res.Ipv4Addr = ipAddr
-	res.TTL = ttl
-	res.UseTTL = useTTL
+	res.Ttl = ttl
+	res.UseTtl = useTTL
 	res.Comment = comment
 	res.Ea = eas
 	res.Ref = ref
@@ -523,8 +523,8 @@ type RecordPTR struct {
 	View     string `json:"view,omitempty"`
 	Zone     string `json:"zone,omitempty"`
 	Ea       EA     `json:"extattrs"`
-	UseTtl   *bool  `json:"use_ttl,omitempty"`
-	Ttl      uint32 `json:"ttl,omitempty"`
+	UseTtl   bool   `json:"use_ttl"`
+	Ttl      uint32 `json:"ttl"`
 	Comment  string `json:"comment,omitempty"`
 }
 
@@ -536,7 +536,7 @@ func NewEmptyRecordPTR() *RecordPTR {
 	return &res
 }
 
-func NewRecordPTR(dnsView string, ptrdname string, useTtl *bool, ttl uint32, comment string, ea EA) *RecordPTR {
+func NewRecordPTR(dnsView string, ptrdname string, useTtl bool, ttl uint32, comment string, ea EA) *RecordPTR {
 	res := NewEmptyRecordPTR()
 	res.View = dnsView
 	res.PtrdName = ptrdname
@@ -598,7 +598,7 @@ type HostRecordIpv4Addr struct {
 	Mac        string `json:"mac,omitempty"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
-	EnableDHCP *bool  `json:"configure_for_dhcp,omitempty"`
+	EnableDhcp bool   `json:"configure_for_dhcp"`
 }
 
 func NewEmptyHostRecordIpv4Addr() *HostRecordIpv4Addr {
@@ -611,14 +611,14 @@ func NewEmptyHostRecordIpv4Addr() *HostRecordIpv4Addr {
 func NewHostRecordIpv4Addr(
 	ipAddr string,
 	macAddr string,
-	enableDHCP *bool,
+	enableDhcp bool,
 	ref string) *HostRecordIpv4Addr {
 
 	res := NewEmptyHostRecordIpv4Addr()
 	res.Ipv4Addr = ipAddr
 	res.Mac = macAddr
 	res.Ref = ref
-	res.EnableDHCP = enableDHCP
+	res.EnableDhcp = enableDhcp
 
 	return res
 }
@@ -630,7 +630,7 @@ type HostRecordIpv6Addr struct {
 	Duid       string `json:"duid,omitempty"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
-	EnableDHCP *bool  `json:"configure_for_dhcp,omitempty"`
+	EnableDhcp bool   `json:"configure_for_dhcp"`
 }
 
 func NewEmptyHostRecordIpv6Addr() *HostRecordIpv6Addr {
@@ -643,14 +643,14 @@ func NewEmptyHostRecordIpv6Addr() *HostRecordIpv6Addr {
 func NewHostRecordIpv6Addr(
 	ipAddr string,
 	duid string,
-	enableDHCP *bool,
+	enableDhcp bool,
 	ref string) *HostRecordIpv6Addr {
 
 	res := NewEmptyHostRecordIpv6Addr()
 	res.Ipv6Addr = ipAddr
 	res.Duid = duid
 	res.Ref = ref
-	res.EnableDHCP = enableDHCP
+	res.EnableDhcp = enableDhcp
 
 	return res
 }
@@ -665,17 +665,19 @@ type HostRecord struct {
 	Name        string               `json:"name,omitempty"`
 	View        string               `json:"view,omitempty"`
 	Zone        string               `json:"zone,omitempty"`
-	EnableDns   *bool                `json:"configure_for_dns,omitempty"`
+	EnableDns   bool                 `json:"configure_for_dns"`
 	NetworkView string               `json:"network_view,omitempty"`
 	Comment     string               `json:"comment"`
 	Ea          EA                   `json:"extattrs"`
+	UseTtl      bool                 `json:"use_ttl"`
+	Ttl         uint32               `json:"ttl"`
 	Aliases     []string             `json:"aliases,omitempty"`
 }
 
 func NewEmptyHostRecord() *HostRecord {
 	res := &HostRecord{}
 	res.objectType = "record:host"
-	res.returnFields = []string{"extattrs", "ipv4addrs", "ipv6addrs", "name", "view", "zone", "comment", "network_view", "aliases"}
+	res.returnFields = []string{"extattrs", "ipv4addrs", "ipv6addrs", "name", "view", "zone", "comment", "network_view", "aliases", "use_ttl", "ttl"}
 
 	return res
 }
@@ -688,10 +690,12 @@ func NewHostRecord(
 	ipv4AddrList []HostRecordIpv4Addr,
 	ipv6AddrList []HostRecordIpv6Addr,
 	eas EA,
-	enableDNS *bool,
+	enableDNS bool,
 	dnsView string,
 	zone string,
 	ref string,
+	useTtl bool,
+	ttl uint32,
 	comment string,
 	aliases []string) *HostRecord {
 
@@ -707,12 +711,10 @@ func NewHostRecord(
 	res.Ipv6Addr = ipv6Addr
 	res.Ipv4Addrs = ipv4AddrList
 	res.Ipv6Addrs = ipv6AddrList
+	res.UseTtl = useTtl
+	res.Ttl = ttl
 	res.Aliases = aliases
-
-	if enableDNS != nil {
-		res.EnableDns = new(bool)
-		*res.EnableDns = *enableDNS
-	}
+	res.EnableDns = enableDNS
 
 	return res
 }


### PR DESCRIPTION
This PR fixes UPDATE functionality of A, AAAA and PTR record. 
With this changes, the update operation when a CIDR is given for all the records would behave as below,

1. Use next available IP feature and get an IP and create a record using allocated IP.
2. When update operation is called check if CIDR is changed,
    - If not changed then do not again use next available IP feature to get a new IP.
    - If changed then get a new IP and use this IP to update the record
 
Allow to create a record with an TTL value of 0 