### PR TITLE
bug fixes on host and fixed address rec

### DIFF
--- a/examples/v0.14/AWS/AllocationAndAssociation/infoblox.tf
+++ b/examples/v0.14/AWS/AllocationAndAssociation/infoblox.tf
@@ -20,8 +20,8 @@ resource "infoblox_ipv4_network_container" "IPv4_nw_c" {
   comment = "tf IPv4 network container"
   ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -32,8 +32,8 @@ resource "infoblox_ipv6_network_container" "IPv6_nw_c" {
   comment = "tf IPv6 network container"
   ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -50,8 +50,8 @@ resource "infoblox_ipv4_network" "ipv4_network"{
   ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -66,8 +66,8 @@ resource "infoblox_ipv6_network" "ipv6_network"{
   ext_attrs = jsonencode({
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -76,11 +76,10 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.aws.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
   
@@ -89,8 +88,8 @@ resource "infoblox_ipv4_allocation" "ipv4_allocation"{
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv4-tf-network"
     "VM Name" =  "tf-ec2-instance"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -98,11 +97,10 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.aws.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -111,8 +109,8 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
     "Tenant ID" = "tf-plugin"
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance-ipv6"
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -123,11 +121,10 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = aws_network_interface.ni.mac_address
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.aws.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -137,8 +134,8 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance"
     "VM ID" =  aws_instance.ec2-instance.id
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
 
@@ -147,11 +144,10 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = aws_network_interface.ni.mac_address
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.aws.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -161,7 +157,51 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
     "Network Name" = "ipv6-tf-network"
     "VM Name" =  "tf-ec2-instance-ipv6"
     "VM ID" =  aws_instance.ec2-instance.id
-    Location = "Test loc."
-    Site = "Test site"
+    "Location" = "Test loc."
+    "Site" = "Test site"
   })
 }
+
+/*
+Below are the examples for Allocation through host and fixed address record creation.
+The same pattern follows for Association and IPv6 address.
+
+# Allocate with default network and dns views
+# Create Host record with default dns flag enabled
+resource "infoblox_ipv4_allocation" "ipv4_allocation"{
+  ip_addr = "10.0.0.11"
+  fqdn="test.aws.com"
+}
+
+# Allocate with default network and dns views
+# Create Host record with dns flag and dhcp flag disabled
+resource "infoblox_ipv4_allocation" "ipv4_allocation"{
+  ip_addr = "10.0.0.11"
+  fqdn="test.aws.com"
+
+  enable_dns = "false"
+  enable_dhcp = "false"
+} 
+
+# Allocate with default network and dns views
+# Create Host record with dns flag and dhcp flag enabled
+resource "infoblox_ipv4_allocation" "ipv4_allocation"{
+  ip_addr = "10.0.0.11"
+  fqdn="test.aws.com"
+
+  enable_dns = "true"
+  enable_dhcp = "true"
+} 
+
+# Allocate with default network and dns views
+# Create Fixed Address record with ip address
+resource "infoblox_ipv4_allocation" "ipv4_allocation"{
+  ip_addr = "10.0.0.11"
+}
+
+# Allocate with default network and dns views
+# Create Fixed Address record with cidr
+resource "infoblox_ipv4_allocation" "ipv4_allocation"{
+  cidr = "10.0.0.0/24"
+}
+*/

--- a/examples/v0.14/Azure/NetworkContainer/IPv4/infoblox.tf
+++ b/examples/v0.14/Azure/NetworkContainer/IPv4/infoblox.tf
@@ -28,11 +28,10 @@ resource "infoblox_ipv4_network" "subnet1"{
 resource "infoblox_ipv4_allocation" "alloc1" {
   network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet1.cidr
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.aws.com"
   #enable_dns = "false"
   #enable_dhcp = "false"  
   

--- a/examples/v0.14/Azure/NetworkContainer/IPv6/infoblox.tf
+++ b/examples/v0.14/Azure/NetworkContainer/IPv6/infoblox.tf
@@ -33,7 +33,7 @@ resource "infoblox_ipv4_allocation" "alloc1" {
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -50,7 +50,7 @@ resource "infoblox_ipv4_association" "assoc1"{
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"  
 
@@ -99,7 +99,7 @@ resource "infoblox_ipv6_allocation" "alloc_reserved" {
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -115,7 +115,7 @@ resource "infoblox_ipv6_allocation" "alloc2" {
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -131,11 +131,10 @@ resource "infoblox_ipv6_association" "assoc2"{
   cidr = infoblox_ipv6_allocation.alloc2.cidr
   mac_addr = local.vm_mac_addr
   ip_addr = infoblox_ipv6_allocation.alloc2.ip_addr
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
   

--- a/examples/v0.14/Azure/NextAvailableNetwork/infoblox.tf
+++ b/examples/v0.14/Azure/NextAvailableNetwork/infoblox.tf
@@ -51,7 +51,7 @@ resource "infoblox_ipv4_allocation" "alloc1" {
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"  
 
@@ -64,11 +64,10 @@ resource "infoblox_ipv4_allocation" "alloc1" {
 resource "infoblox_ipv4_allocation" "alloc2" {
   network_view=infoblox_network_view.nv1.network_view
   cidr=infoblox_ipv4_network.subnet2.cidr
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 

--- a/examples/v0.14/VMWare/AllocationAndAssociation/infoblox.tf
+++ b/examples/v0.14/VMWare/AllocationAndAssociation/infoblox.tf
@@ -60,11 +60,10 @@ resource "infoblox_ipv6_network" "ipv6_network"{
 resource "infoblox_ipv4_allocation" "ipv4_allocation"{
   network_view= "default"
   cidr = infoblox_ipv4_network.ipv4_network.cidr
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -82,11 +81,10 @@ resource "infoblox_ipv6_allocation" "ipv6_allocation" {
   network_view= "default"
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   duid = "00:00:00:00:00:00:00:00"
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -106,11 +104,10 @@ resource "infoblox_ipv4_association" "ipv4_associate"{
   cidr = infoblox_ipv4_network.ipv4_network.cidr
   ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
   mac_addr = vsphere_virtual_machine.vm_ipv4.network_interface[0].mac_address
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv4.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 
@@ -130,11 +127,10 @@ resource "infoblox_ipv6_association" "ipv6_associate"{
   cidr = infoblox_ipv6_network.ipv6_network.cidr
   ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
   duid = vsphere_virtual_machine.vm_ipv6.network_interface[0].mac_address
-  host_name = "test"
 
   #Create Host Record with DNS and DHCP flags
   #dns_view="default"
-  #zone="aws.com"
+  #fqdn="testipv6.vmware.com"
   #enable_dns = "false"
   #enable_dhcp = "false"
 

--- a/infoblox/resource_infoblox_ip_allocation_test.go
+++ b/infoblox/resource_infoblox_ip_allocation_test.go
@@ -11,12 +11,12 @@ import (
 
 var testAccresourceIPv4AllocationCreate = fmt.Sprintf(`
 resource "infoblox_ipv4_allocation" "foo"{
-	network_view_name="%s"
-	host_name="testHostName"
+	network_view="%s"
+	fqdn="testHostName.aws.com"
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	comment = "10.0.0.1 IP is allocated"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"VM Name" =  "tf-ec2-instance"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc."
@@ -28,12 +28,12 @@ resource "infoblox_ipv4_allocation" "foo"{
 
 var testAccresourceIPv4AllocationUpdate = fmt.Sprintf(`
 resource "infoblox_ipv4_allocation" "foo"{
-	network_view_name="%s"
-	host_name="testHostName"
+	network_view="%s"
+	fqdn="testHostName.aws.com"
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	comment = "10.0.0.1 IP is allocated updated"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"VM Name" =  "tf-ec2-instance"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc. updated"
@@ -44,12 +44,12 @@ resource "infoblox_ipv4_allocation" "foo"{
 
 var testAccresourceIPv6AllocationCreate = fmt.Sprintf(`
 	resource "infoblox_ipv6_allocation" "foo"{
-		network_view_name="%s"
+		network_view="%s"
 		cidr="2001:db8:abcd:12::/64"
 		ip_addr="2001:db8:abcd:12::1"
 		duid="11:22:33:44:55:66"
 		comment = "2001:db8:abcd:12::1 IP is allocated"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"VM Name" =  "tf-ec2-instance-ipv6"
 			"Tenant ID" = "terraform_test_tenant"
 			Location = "Test loc."
@@ -61,12 +61,12 @@ var testAccresourceIPv6AllocationCreate = fmt.Sprintf(`
 
 var testAccresourceIPv6AllocationUpdate = fmt.Sprintf(`
 	resource "infoblox_ipv6_allocation" "foo"{
-		network_view_name="%s"
+		network_view="%s"
 		cidr="2001:db8:abcd:12::/64"
 		ip_addr="2001:db8:abcd:12::1"
 		duid="11:22:33:44:55:66"
 		comment = "2001:db8:abcd:12::1 IP is allocated updated"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"VM Name" =  "tf-ec2-instance-ipv6"
 			"Tenant ID" = "terraform_test_tenant"
 			Location = "Test loc. updated"
@@ -106,7 +106,7 @@ func validateIPAllocation(
 		expNv := expectedValue.NetviewName
 		if ipAlloc.NetviewName != expNv {
 			return fmt.Errorf(
-				"the value of 'network_view_name' field is '%s', but expected '%s'",
+				"the value of 'network_view' field is '%s', but expected '%s'",
 				ipAlloc.NetviewName, expNv)
 		}
 
@@ -129,11 +129,11 @@ func validateIPAllocation(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && ipAlloc.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && ipAlloc.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil

--- a/infoblox/resource_infoblox_ip_association.go
+++ b/infoblox/resource_infoblox_ip_association.go
@@ -12,11 +12,17 @@ import (
 func resourceIPAssociation() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"network_view_name": &schema.Schema{
+			"network_view": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "default",
 				Description: "Network view name of NIOS server.",
+			},
+			"dns_view": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "default",
+				Description: "view in which record has to be created.",
 			},
 			"enable_dns": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -30,20 +36,9 @@ func resourceIPAssociation() *schema.Resource {
 				Default:     false,
 				Description: "flag that defines if the host record is to be used for IPAM Purposes.",
 			},
-			"dns_view": &schema.Schema{
+			"cidr": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "default",
-				Description: "view in which record has to be created.",
-			},
-			"zone": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "zone under which record has been created.",
-			},
-			"cidr": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
 				Description: "The address in cidr format.",
 			},
 			"ip_addr": &schema.Schema{
@@ -61,10 +56,16 @@ func resourceIPAssociation() *schema.Resource {
 				Optional:    true,
 				Description: "DHCP unique identifier for IPv6.",
 			},
-			"host_name": {
+			"fqdn": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The host name",
+				Optional:    true,
+				Description: "The host name for Host Record in FQDN format.",
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "TTL attribute value for the record.",
 			},
 			"comment": {
 				Type:        schema.TypeString,
@@ -72,11 +73,11 @@ func resourceIPAssociation() *schema.Resource {
 				Optional:    true,
 				Description: "A description of the IP association.",
 			},
-			"extensible_attributes": {
+			"ext_attrs": {
 				Type:        schema.TypeString,
 				Default:     "",
 				Optional:    true,
-				Description: "The Extensible attributes of the network container to be added/updated, as a map in JSON format",
+				Description: "The Extensible attributes for IP Association, as a map in JSON format",
 			},
 		},
 	}
@@ -98,6 +99,13 @@ func resourceIPAssociationCreate(d *schema.ResourceData, m interface{}, isIPv6 b
 
 func resourceIPAssociationUpdate(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
 
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'networkView' field is not allowed")
+	}
+	if d.HasChange("dns_view") {
+		return fmt.Errorf("changing the value of 'dns_view' field is not allowed")
+	}
+
 	if err := Resource(d, m, isIPv6); err != nil {
 		return err
 	}
@@ -107,54 +115,37 @@ func resourceIPAssociationUpdate(d *schema.ResourceData, m interface{}, isIPv6 b
 
 func resourceIPAssociationRead(d *schema.ResourceData, m interface{}) error {
 
-	enableDns := d.Get("enable_dns").(bool)
-	enableDhcp := d.Get("enable_dhcp").(bool)
-	hostName := d.Get("host_name").(string)
+	fqdn := d.Get("fqdn").(string)
 
-	cidr := d.Get("cidr").(string)
-	dnsView := d.Get("dns_view").(string)
-	zone := d.Get("zone").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
-
 	var tenantID string
-	for attrName, attrValueInf := range extAttrs {
-		attrValue, _ := attrValueInf.(string)
-		if attrName == "Tenant ID" {
-			tenantID = attrValue
-		}
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
 	}
 
-	if hostName == "" {
-		return fmt.Errorf("'host_name' is mandatory to be passed for Association of IP")
-	}
-
-	connector := m.(*ibclient.Connector)
+	connector := m.(ibclient.IBConnector)
 	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 
-	if (zone != "" || len(zone) != 0) && (dnsView != "" || len(dnsView) != 0) && enableDns {
-		obj, err := objMgr.GetHostRecordByRef(d.Id())
+	if fqdn != "" {
+		hostRec, err := objMgr.GetHostRecordByRef(d.Id())
 		if err != nil {
-			return fmt.Errorf("Error getting IP from network block %s: %s", cidr, err.Error())
+			return fmt.Errorf("Error getting Allocated HostRecord with ID: %s failed : %s",
+				d.Id(), err.Error())
 		}
-		d.SetId(obj.Ref)
-	} else if enableDhcp || !enableDns {
-		obj, err := objMgr.GetHostRecordByRef(d.Id())
-		if err != nil {
-			return fmt.Errorf("Error getting IP from network block %s: %s", cidr, err.Error())
-		}
-		d.SetId(obj.Ref)
+		d.SetId(hostRec.Ref)
 	} else {
-		obj, err := objMgr.GetFixedAddressByRef(d.Id())
+		fixedAddress, err := objMgr.GetFixedAddressByRef(d.Id())
 		if err != nil {
-			return fmt.Errorf("Error getting IP from network block %s: %s", cidr, err.Error())
+			return fmt.Errorf("Error getting FixedAddress Record with ID: %s failed : %s",
+				d.Id(), err.Error())
 		}
-		d.SetId(obj.Ref)
+		d.SetId(fixedAddress.Ref)
 	}
 	return nil
 }
@@ -164,124 +155,138 @@ func resourceIPAssociationRead(d *schema.ResourceData, m interface{}) error {
 //will be a conflict of resources
 func resourceIPAssociationDelete(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
 
-	ipAddr := d.Get("ip_addr").(string)
-	hostName := d.Get("host_name").(string)
-
+	networkView := d.Get("network_view").(string)
+	if d.HasChange("network_view") {
+		return fmt.Errorf("changing the value of 'networkView' field is not allowed")
+	}
+	if d.HasChange("dns_view") {
+		return fmt.Errorf("changing the value of 'dns_view' field is not allowed")
+	}
 	enableDns := d.Get("enable_dns").(bool)
 	enableDhcp := d.Get("enable_dhcp").(bool)
-	dnsView := d.Get("dns_view").(string)
-	zone := d.Get("zone").(string)
+	fqdn := d.Get("fqdn").(string)
+	cidr := d.Get("cidr").(string)
+	ipAddr := d.Get("ip_addr").(string)
 	duid := d.Get("duid").(string)
 
+	var ttl uint32
+	tempVal, useTtl := d.GetOk("ttl")
+	if useTtl {
+		tempTtl := tempVal.(int)
+		if tempTtl < 0 {
+			return fmt.Errorf("TTL value must be 0 or higher")
+		}
+		ttl = uint32(tempTtl)
+	}
+
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
-	for attrName, attrValueInf := range extAttrs {
-		attrValue, _ := attrValueInf.(string)
-		if attrName == "Tenant ID" {
-			tenantID = attrValue
-		}
-	}
-
-	if hostName == "" {
-		return fmt.Errorf("'host_name' is mandatory to be passed for removal of Association")
-	}
-
-	var recFQDN string
-	if len(zone) > 0 {
-		recFQDN = hostName + "." + zone
-	} else {
-		recFQDN = hostName
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
 	}
 
 	ZeroMacAddr := "00:00:00:00:00:00"
-	connector := m.(*ibclient.Connector)
+	connector := m.(ibclient.IBConnector)
 	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 
-	if (zone != "" || len(zone) != 0) && (dnsView != "" || len(dnsView) != 0) && enableDns {
+	if fqdn != "" && enableDns {
 		if isIPv6 {
-			obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				d.Id(),
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				"", cidr,
 				"", ipAddr,
 				"", duid,
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("Error updating Host record of IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error updating Host record with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(obj.Ref)
+			d.SetId(hostRec.Ref)
 		} else {
-			obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				d.Id(),
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				cidr, "",
 				ipAddr, "",
 				ZeroMacAddr, "",
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("Error updating Host record of IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error updating Host record with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(obj.Ref)
+			d.SetId(hostRec.Ref)
 		}
 	} else if enableDhcp || !enableDns {
-		// default value of enableDns is true. When user sets enableDhcp as true and does not pass a enableDns flag
+		// change default value of enableDns to false, when user sets enableDhcp but not pass a enableDns flag
 		enableDns = false
 
 		if isIPv6 {
-			obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				d.Id(),
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				"", cidr,
 				"", ipAddr,
 				"", duid,
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("Error updating Host record of IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error updating Host record with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(obj.Ref)
+			d.SetId(hostRec.Ref)
 		} else {
-			obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				d.Id(),
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				cidr, "",
 				ipAddr, "",
 				ZeroMacAddr, "",
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("Error updating Host record of IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error updating Host record with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(obj.Ref)
+			d.SetId(hostRec.Ref)
 		}
 	} else {
 		matchClient := "MAC_ADDRESS"
 		if isIPv6 {
 			matchClient = ""
-			_, err := objMgr.UpdateFixedAddress(d.Id(), hostName, matchClient, duid, comment, extAttrs)
+			fixedAddress, err := objMgr.UpdateFixedAddress(d.Id(), networkView, fqdn, cidr, ipAddr, matchClient, duid, comment, extAttrs)
 			if err != nil {
-				return fmt.Errorf("Error Releasing IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error Releasing IP with ID %s: %s", d.Id(), err.Error())
 			}
+			d.SetId(fixedAddress.Ref)
 		} else {
-			_, err := objMgr.UpdateFixedAddress(d.Id(), hostName, matchClient, ZeroMacAddr, comment, extAttrs)
+			fixedAddress, err := objMgr.UpdateFixedAddress(d.Id(), networkView, fqdn, cidr, ipAddr, matchClient, duid, comment, extAttrs)
 			if err != nil {
-				return fmt.Errorf("Error Releasing IP from network block having reference %s: %s", d.Id(), err.Error())
+				return fmt.Errorf("Error Releasing IP with ID %s: %s", d.Id(), err.Error())
 			}
+			d.SetId(fixedAddress.Ref)
 		}
-		d.SetId("")
 	}
 
 	return nil
@@ -289,144 +294,161 @@ func resourceIPAssociationDelete(d *schema.ResourceData, m interface{}, isIPv6 b
 
 func Resource(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
 
-	networkViewName := d.Get("network_view_name").(string)
-	enableDns := d.Get("enable_dns").(bool)
-	enableDhcp := d.Get("enable_dhcp").(bool)
+	networkView := d.Get("network_view").(string)
 	dnsView := d.Get("dns_view").(string)
-	zone := d.Get("zone").(string)
-	hostName := d.Get("host_name").(string)
+	enableDhcp := d.Get("enable_dhcp").(bool)
+	enableDns := d.Get("enable_dns").(bool)
+	// dnsView made empty so that searching of host record to be done at IPAM end
+	if !enableDns {
+		dnsView = ""
+	}
 
+	fqdn := d.Get("fqdn").(string)
 	cidr := d.Get("cidr").(string)
 	ipAddr := d.Get("ip_addr").(string)
 	macAddr := d.Get("mac_addr").(string)
+	//conversion from bit reversed EUI-48 format to hexadecimal EUI-48 format
+	macAddr = strings.Replace(macAddr, "-", ":", -1)
 	duid := d.Get("duid").(string)
 
+	var ttl uint32
+	tempVal, useTtl := d.GetOk("ttl")
+	if useTtl {
+		tempTtl := tempVal.(int)
+		if tempTtl < 0 {
+			return fmt.Errorf("TTL value must be 0 or higher")
+		}
+		ttl = uint32(tempTtl)
+	}
 	comment := d.Get("comment").(string)
-	extAttrJSON := d.Get("extensible_attributes").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
 	extAttrs := make(map[string]interface{})
 	if extAttrJSON != "" {
 		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
-			return fmt.Errorf("cannot process 'extensible_attributes' field: %s", err.Error())
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
 		}
 	}
 	var tenantID string
-	for attrName, attrValue := range extAttrs {
-		attrValue, _ := attrValue.(string)
-		if attrName == "Tenant ID" {
-			tenantID = attrValue
-		}
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
 	}
 
-	if hostName == "" {
-		return fmt.Errorf("'host_name' is mandatory to be passed for Association")
-	}
-
-	//conversion from bit reversed EUI-48 format to hexadecimal EUI-48 format
-	macAddr = strings.Replace(macAddr, "-", ":", -1)
-	var recFQDN string
-	if len(zone) > 0 {
-		recFQDN = hostName + "." + zone
-	} else {
-		recFQDN = hostName
-	}
-
-	connector := m.(*ibclient.Connector)
+	connector := m.(ibclient.IBConnector)
 	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 
-	//var err error
-	if (zone != "" || len(zone) != 0) && (dnsView != "" || len(dnsView) != 0) && enableDns {
+	if fqdn != "" && enableDns {
 		if isIPv6 {
-			hostRecordObj, err := objMgr.GetHostRecord(recFQDN, "", ipAddr)
+			hostRecordObj, err := objMgr.GetHostRecord(networkView, dnsView, fqdn, "", ipAddr)
 			if err != nil {
-				return fmt.Errorf("GetHostRecord failed from IPv6 network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("Failed to get HostRecord for 'fqdn': %s and 'IP':%s in"+
+					"'network view': %s and 'dns view':%s. Error:%s",
+					fqdn, ipAddr, networkView, dnsView, err.Error())
 			}
 			if hostRecordObj == nil {
-				return fmt.Errorf("HostRecord %s not found.", recFQDN)
+				return fmt.Errorf("HostRecord %s not found.", fqdn)
 			}
-			Obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				hostRecordObj.Ref,
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				"", cidr,
 				"", ipAddr,
 				"", duid,
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("UpdateHost Record failed from IPv6 network block %s: %s", cidr, err.Error())
+				return fmt.Errorf("UpdateHost Record failed with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(Obj.Ref)
+			d.SetId(hostRec.Ref)
 		} else {
-			hostRecordObj, err := objMgr.GetHostRecord(recFQDN, ipAddr, "")
+			hostRecordObj, err := objMgr.GetHostRecord(networkView, dnsView, fqdn, ipAddr, "")
 			if err != nil {
-				return fmt.Errorf("GetHostRecord failed from IPv4 network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("Failed to get HostRecord for 'fqdn': %s and 'IP':%s in"+
+					"'network view': %s and 'dns view':%s. Error:%s",
+					fqdn, ipAddr, networkView, dnsView, err.Error())
 			}
 			if hostRecordObj == nil {
-				return fmt.Errorf("HostRecord %s not found.", recFQDN)
+				return fmt.Errorf("HostRecord %s not found.", fqdn)
 			}
-			Obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				hostRecordObj.Ref,
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				cidr, "",
 				ipAddr, "",
 				macAddr, "",
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("UpdateHost Record failed from network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("UpdateHost Record failed with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(Obj.Ref)
+			d.SetId(hostRec.Ref)
 		}
-	} else if enableDhcp || !enableDns {
-		// default value of enableDns is true. When user sets enableDhcp as true and does not pass a enableDns flag
+	} else if fqdn != "" && enableDhcp || !enableDns {
+		// change default value of enableDns to false, when user sets enableDhcp but not pass a enableDns flag
 		enableDns = false
 
 		if isIPv6 {
-			hostRecordObj, err := objMgr.GetHostRecord(recFQDN, "", ipAddr)
+			hostRecordObj, err := objMgr.GetHostRecord(networkView, dnsView, fqdn, "", ipAddr)
 			if err != nil {
-				return fmt.Errorf("GetHostRecord failed from IPv6 network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("Failed to get HostRecord for 'fqdn': %s and 'IP':%s in"+
+					"'network view': %s and 'dns view':%s. Error:%s",
+					fqdn, ipAddr, networkView, dnsView, err.Error())
 			}
 			if hostRecordObj == nil {
-				return fmt.Errorf("HostRecord %s not found.", recFQDN)
+				return fmt.Errorf("HostRecord %s not found.", fqdn)
 			}
-			Obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				hostRecordObj.Ref,
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				"", cidr,
 				"", ipAddr,
 				"", duid,
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("UpdateHost Record failed from IPv6 network block %s: %s", cidr, err.Error())
+				return fmt.Errorf("UpdateHost Record failed with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(Obj.Ref)
+			d.SetId(hostRec.Ref)
 		} else {
-			hostRecordObj, err := objMgr.GetHostRecord(recFQDN, ipAddr, "")
+			hostRecordObj, err := objMgr.GetHostRecord(networkView, dnsView, fqdn, ipAddr, "")
 			if err != nil {
-				return fmt.Errorf("GetHostRecord failed from IPv4 network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("Failed to get HostRecord for 'fqdn': %s and 'IP':%s in"+
+					"'network view': %s and 'dns view':%s. Error:%s",
+					fqdn, ipAddr, networkView, dnsView, err.Error())
 			}
 			if hostRecordObj == nil {
-				return fmt.Errorf("HostRecord %s not found.", recFQDN)
+				return fmt.Errorf("HostRecord %s not found.", fqdn)
 			}
-			Obj, err := objMgr.UpdateHostRecord(
+			hostRec, err := objMgr.UpdateHostRecord(
 				hostRecordObj.Ref,
 				enableDns,
 				enableDhcp,
-				recFQDN,
+				fqdn,
+				networkView,
+				cidr, "",
 				ipAddr, "",
 				macAddr, "",
+				useTtl, ttl,
 				comment,
 				extAttrs, []string{})
 			if err != nil {
-				return fmt.Errorf("UpdateHost Record failed from network block %s:%s", cidr, err.Error())
+				return fmt.Errorf("UpdateHost Record failed with ID %s: %s", d.Id(), err.Error())
 			}
-			d.SetId(Obj.Ref)
+			d.SetId(hostRec.Ref)
 		}
 	} else {
-		fixedAddressObj, err := objMgr.GetFixedAddress(networkViewName, cidr, ipAddr, isIPv6, "")
+		fixedAddressObj, err := objMgr.GetFixedAddress(networkView, cidr, ipAddr, isIPv6, "")
 		if err != nil {
 			return fmt.Errorf("GetFixedAddress failed from network block %s:%s", cidr, err.Error())
 		}
@@ -434,18 +456,21 @@ func Resource(d *schema.ResourceData, m interface{}, isIPv6 bool) error {
 			return fmt.Errorf("FixedAddress %s not found in network %s.", ipAddr, cidr)
 		}
 
-		var macOrDuid string
-		macOrDuid = macAddr
 		matchClient := "MAC_ADDRESS"
 		if isIPv6 {
 			matchClient = ""
-			macOrDuid = duid
+			fixedAddress, err := objMgr.UpdateFixedAddress(fixedAddressObj.Ref, networkView, fqdn, cidr, ipAddr, matchClient, duid, comment, extAttrs)
+			if err != nil {
+				return fmt.Errorf("Error Releasing IP with ID %s: %s", d.Id(), err.Error())
+			}
+			d.SetId(fixedAddress.Ref)
+		} else {
+			fixedAddress, err := objMgr.UpdateFixedAddress(fixedAddressObj.Ref, networkView, fqdn, cidr, ipAddr, matchClient, duid, comment, extAttrs)
+			if err != nil {
+				return fmt.Errorf("Error Releasing IP with ID %s: %s", d.Id(), err.Error())
+			}
+			d.SetId(fixedAddress.Ref)
 		}
-		_, err = objMgr.UpdateFixedAddress(fixedAddressObj.Ref, hostName, matchClient, macOrDuid, comment, extAttrs)
-		if err != nil {
-			return fmt.Errorf("UpdateFixedAddress error from network block %s:%s", cidr, err.Error())
-		}
-		d.SetId(fixedAddressObj.Ref)
 	}
 	return nil
 }

--- a/infoblox/resource_infoblox_ip_association_test.go
+++ b/infoblox/resource_infoblox_ip_association_test.go
@@ -11,12 +11,12 @@ import (
 
 var testAccresourceIPv4AssociationCreate = fmt.Sprintf(`
 resource "infoblox_ipv4_association" "foo"{
-	network_view_name="%s"
+	network_view="%s"
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	mac_addr="11:22:33:44:55:66"
 	comment = "10.0.0.1 IP is associated "
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"VM Name" =  "tf-ec2-instance"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc."
@@ -28,12 +28,12 @@ resource "infoblox_ipv4_association" "foo"{
 
 var testAccresourceIPv4AssociationUpdate = fmt.Sprintf(`
 resource "infoblox_ipv4_association" "foo"{
-	network_view_name="%s"
+	network_view="%s"
 	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.1"
 	mac_addr="11:22:33:44:55:66"
 	comment = "10.0.0.1 IP is associated updated"
-	extensible_attributes = jsonencode({
+	ext_attrs = jsonencode({
 		"VM Name" =  "tf-ec2-instance"
 		"Tenant ID" = "terraform_test_tenant"
 		Location = "Test loc. updated"
@@ -44,12 +44,12 @@ resource "infoblox_ipv4_association" "foo"{
 
 var testAccresourceIPv6AssociationCreate = fmt.Sprintf(`
 	resource "infoblox_ipv6_association" "foo"{
-		network_view_name="%s"
+		network_view="%s"
 		cidr="2001:db8:abcd:12::/64"
 		ip_addr="2001:db8:abcd:12::1"
 		duid="11:22:33:44:55:66"
 		comment = "2001:db8:abcd:12::1 IP is associated"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"VM Name" =  "tf-ec2-instance-ipv6"
 			"Tenant ID" = "terraform_test_tenant"
 			Location = "Test loc."
@@ -61,12 +61,12 @@ var testAccresourceIPv6AssociationCreate = fmt.Sprintf(`
 
 var testAccresourceIPv6AssociationUpdate = fmt.Sprintf(`
 	resource "infoblox_ipv6_association" "foo"{
-		network_view_name="%s"
+		network_view="%s"
 		cidr="2001:db8:abcd:12::/64"
 		ip_addr="2001:db8:abcd:12::1"
 		duid="11:22:33:44:55:66"
 		comment = "2001:db8:abcd:12::1 IP is associated updated"
-		extensible_attributes = jsonencode({
+		ext_attrs = jsonencode({
 			"VM Name" =  "tf-ec2-instance-ipv6"
 			"Tenant ID" = "terraform_test_tenant"
 			Location = "Test loc. updated"
@@ -106,7 +106,7 @@ func validateIPAssociation(
 		expNv := expectedValue.NetviewName
 		if ipAsso.NetviewName != expNv {
 			return fmt.Errorf(
-				"the value of 'network_view_name' field is '%s', but expected '%s'",
+				"the value of 'network_view' field is '%s', but expected '%s'",
 				ipAsso.NetviewName, expNv)
 		}
 
@@ -137,11 +137,11 @@ func validateIPAssociation(
 		expectedEAs := expectedValue.Ea
 		if expectedEAs == nil && ipAsso.Ea != nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has 'extensible_attributes' field, but it is not expected to exist", id)
+				"the object with ID '%s' has 'ext_attrs' field, but it is not expected to exist", id)
 		}
 		if expectedEAs != nil && ipAsso.Ea == nil {
 			return fmt.Errorf(
-				"the object with ID '%s' has no 'extensible_attributes' field, but it is expected to exist", id)
+				"the object with ID '%s' has no 'ext_attrs' field, but it is expected to exist", id)
 		}
 		if expectedEAs == nil {
 			return nil


### PR DESCRIPTION
Fixes some important bugs. Below are the list of the same,

- "host_name" field is not mandatory while Creating of Fixed address object
- Difference in behavior for Host record update for the dynamic IP address allocation
- Need to support ttl field for DNS Host record object
- TTL value is not setting to Zero in the Created records
- Terraform update for Fixed address "ip-addr" is not working
- Resources not deleting when a leading or trailing space are specified in network view value under a resource group

Solves #50 