### PR TITLE
creating a uniform zone accorss UTs

### DIFF
--- a/infoblox/datasource_infoblox_a_record_test.go
+++ b/infoblox/datasource_infoblox_a_record_test.go
@@ -16,8 +16,8 @@ func TestAccDataSourceARecord(t *testing.T) {
 				Config: testAccDataSourceARecordsRead,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "dns_view", "default"),
-					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "zone", "aws.com"),
-					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "fqdn", "test-name.aws.com"),
+					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "zone", "test.com"),
+					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "fqdn", "test-name.test.com"),
 					resource.TestCheckResourceAttr("data.infoblox_a_record.acctest", "ip_addr", "10.0.0.20"),
 				),
 			},
@@ -28,7 +28,7 @@ func TestAccDataSourceARecord(t *testing.T) {
 var testAccDataSourceARecordsRead = fmt.Sprintf(`
 resource "infoblox_a_record" "foo"{
 	dns_view="default"
-	fqdn="test-name.aws.com"
+	fqdn="test-name.test.com"
 	ip_addr="10.0.0.20"
 }
 

--- a/infoblox/datasource_infoblox_cname_record_test.go
+++ b/infoblox/datasource_infoblox_cname_record_test.go
@@ -16,9 +16,9 @@ func TestAccDataSourceCNameRecord(t *testing.T) {
 				Config: testAccDataSourceCNameRecordsRead,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "dns_view", "default"),
-					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "zone", "aws.com"),
-					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "alias", "test.aws.com"),
-					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "canonical", "test-name.aws.com"),
+					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "zone", "test.com"),
+					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "alias", "test.test.com"),
+					resource.TestCheckResourceAttr("data.infoblox_cname_record.acctest", "canonical", "test-name.test.com"),
 				),
 			},
 		},
@@ -29,8 +29,8 @@ var testAccDataSourceCNameRecordsRead = fmt.Sprintf(`
 resource "infoblox_cname_record" "foo"{
 	dns_view="default"
 	
-	alias="test.aws.com"
-	canonical="test-name.aws.com"	
+	alias="test.test.com"
+	canonical="test-name.test.com"	
   }
 
 data "infoblox_cname_record" "acctest" {

--- a/infoblox/resource_infoblox_a_record_test.go
+++ b/infoblox/resource_infoblox_a_record_test.go
@@ -91,13 +91,13 @@ func TestAccResourceARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_a_record" "foo"{
-						fqdn = "name1.aws.com"
+						fqdn = "name1.test.com"
 						ip_addr = "10.0.0.2"
 					}`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccARecordCompare(t, "infoblox_a_record.foo", &ibclient.RecordA{
 						Ipv4Addr: "10.0.0.2",
-						Name:     "name1.aws.com",
+						Name:     "name1.test.com",
 						View:     "default",
 						Ttl:      0,
 						UseTtl:   false,
@@ -109,7 +109,7 @@ func TestAccResourceARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_a_record" "foo2"{
-						fqdn = "name2.aws.com"
+						fqdn = "name2.test.com"
 						ip_addr = "192.168.31.31"
 						ttl = 10
 						dns_view = "nondefault_view"
@@ -122,7 +122,7 @@ func TestAccResourceARecord(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccARecordCompare(t, "infoblox_a_record.foo2", &ibclient.RecordA{
 						Ipv4Addr: "192.168.31.31",
-						Name:     "name2.aws.com",
+						Name:     "name2.test.com",
 						View:     "nondefault_view",
 						Ttl:      10,
 						UseTtl:   true,
@@ -137,7 +137,7 @@ func TestAccResourceARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_a_record" "foo2"{
-						fqdn = "name3.aws.com"
+						fqdn = "name3.test.com"
 						ip_addr = "10.10.0.1"
 						ttl = 155
 						dns_view = "nondefault_view"
@@ -146,7 +146,7 @@ func TestAccResourceARecord(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccARecordCompare(t, "infoblox_a_record.foo2", &ibclient.RecordA{
 						Ipv4Addr: "10.10.0.1",
-						Name:     "name3.aws.com",
+						Name:     "name3.test.com",
 						View:     "nondefault_view",
 						Ttl:      155,
 						UseTtl:   true,
@@ -157,14 +157,14 @@ func TestAccResourceARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_a_record" "foo2"{
-						fqdn = "name3.aws.com"
+						fqdn = "name3.test.com"
 						ip_addr = "10.10.0.1"
 						dns_view = "nondefault_view"
 					}`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccARecordCompare(t, "infoblox_a_record.foo2", &ibclient.RecordA{
 						Ipv4Addr: "10.10.0.1",
-						Name:     "name3.aws.com",
+						Name:     "name3.test.com",
 						View:     "nondefault_view",
 						UseTtl:   false,
 					}),

--- a/infoblox/resource_infoblox_aaaa_record_test.go
+++ b/infoblox/resource_infoblox_aaaa_record_test.go
@@ -84,7 +84,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_aaaa_record" "foo"{
-						fqdn = "name1.aws.com"
+						fqdn = "name1.test.com"
 						ipv6_addr = "2000::1"
 						dns_view = "default"
 						comment = "test comment 1"
@@ -98,7 +98,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAAAARecordCompare(t, "infoblox_aaaa_record.foo", &ibclient.RecordAAAA{
 						Ipv6Addr: "2000::1",
-						Name:     "name1.aws.com",
+						Name:     "name1.test.com",
 						View:     "default",
 						Ttl:      0,
 						Comment:  "test comment 1",
@@ -114,7 +114,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "infoblox_aaaa_record" "foo2"{
-						fqdn = "name3.aws.com"
+						fqdn = "name3.test.com"
 						ipv6_addr = "2000::3"
 						ttl = 155
 						dns_view = "default"
@@ -127,7 +127,7 @@ func TestAccResourceAAAARecord(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAAAARecordCompare(t, "infoblox_aaaa_record.foo2", &ibclient.RecordAAAA{
 						Ipv6Addr: "2000::3",
-						Name:     "name3.aws.com",
+						Name:     "name3.test.com",
 						View:     "default",
 						Ttl:      155,
 						Comment:  "test comment 2",

--- a/infoblox/resource_infoblox_cname_record_test.go
+++ b/infoblox/resource_infoblox_cname_record_test.go
@@ -12,8 +12,8 @@ import (
 var testAccresourceCNAMERecordCreate = fmt.Sprintf(`
 resource "infoblox_cname_record" "foo"{
 	dns_view="default"
-	canonical="test-canonicalName.aws.com"
-	alias="test-aliasname.aws.com"
+	canonical="test-canonicalName.test.com"
+	alias="test-aliasname.test.com"
 	comment="CNAME record created"
 	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
@@ -27,8 +27,8 @@ resource "infoblox_cname_record" "foo"{
 var testAccresourceCNAMERecordUpdate = fmt.Sprintf(`
 resource "infoblox_cname_record" "foo"{
 	dns_view="default"
-	canonical="test-canonicalName.aws.com"
-	alias="test-aliasname.aws.com"
+	canonical="test-canonicalName.test.com"
+	alias="test-aliasname.test.com"
 	comment="CNAME record updated"
 	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
@@ -119,9 +119,9 @@ func TestAccResourceCNAMERecord(t *testing.T) {
 					"infoblox_cname_record.foo",
 					&ibclient.RecordCNAME{
 						View:      "default",
-						Canonical: "test-canonicalName.aws.com",
-						Name:      "test-aliasname.aws.com",
-						Zone:      "aws.com",
+						Canonical: "test-canonicalName.test.com",
+						Name:      "test-aliasname.test.com",
+						Zone:      "test.com",
 						Comment:   "CNAME record created",
 						Ea: ibclient.EA{
 							"Tenant ID": "terraform_test_tenant",
@@ -138,9 +138,9 @@ func TestAccResourceCNAMERecord(t *testing.T) {
 					"infoblox_cname_record.foo",
 					&ibclient.RecordCNAME{
 						View:      "default",
-						Canonical: "test-canonicalName.aws.com",
-						Name:      "test-aliasname.aws.com",
-						Zone:      "aws.com",
+						Canonical: "test-canonicalName.test.com",
+						Name:      "test-aliasname.test.com",
+						Zone:      "test.com",
 						Comment:   "CNAME record updated",
 						Ea: ibclient.EA{
 							"Tenant ID": "terraform_test_tenant",

--- a/infoblox/resource_infoblox_ip_allocation_test.go
+++ b/infoblox/resource_infoblox_ip_allocation_test.go
@@ -87,7 +87,7 @@ func TestAcc_resourceIPAllocation_ipv4(t *testing.T) {
 				resource "infoblox_ipv4_allocation" "foo"{
 					network_view="default"
 					dns_view = "default"
-					fqdn="testhostname.aws.com"
+					fqdn="testhostname.test.com"
 					cidr="10.0.0.0/24"
 					ip_addr="10.0.0.1"
 					enable_dns = "true"
@@ -104,7 +104,7 @@ func TestAcc_resourceIPAllocation_ipv4(t *testing.T) {
 					&ibclient.HostRecord{
 						NetworkView: "default",
 						View:        "default",
-						Name:        "testhostname.aws.com",
+						Name:        "testhostname.test.com",
 						Ipv4Addr:    "10.0.0.1",
 						Comment:     "10.0.0.1 IP is allocated",
 						Ea: ibclient.EA{
@@ -131,7 +131,7 @@ func TestAcc_resourceIPAllocation_ipv6(t *testing.T) {
 				resource "infoblox_ipv6_allocation" "foo2"{
 					network_view="default"
 					dns_view = "default"
-					fqdn="testhostnameipv6.aws.com"
+					fqdn="testhostnameipv6.test.com"
 					ip_addr="2001:db8:abcd:12::1"
 					duid="11:22:33:44:55:66"
 					comment = "2001:db8:abcd:12::1 IP is allocated"
@@ -147,7 +147,7 @@ func TestAcc_resourceIPAllocation_ipv6(t *testing.T) {
 					&ibclient.HostRecord{
 						NetworkView: "default",
 						View:        "default",
-						Name:        "testhostnameipv6.aws.com",
+						Name:        "testhostnameipv6.test.com",
 						Ipv6Addr:    "2001:db8:abcd:12::1",
 						Comment:     "2001:db8:abcd:12::1 IP is allocated",
 						Ea: ibclient.EA{

--- a/infoblox/resource_infoblox_ip_association_test.go
+++ b/infoblox/resource_infoblox_ip_association_test.go
@@ -128,7 +128,7 @@ func TestAcc_resourceipAssociation_ipv4(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "infoblox_ipv4_allocation" "foo"{
 					network_view="default"
-					fqdn="testhostname.aws.com"
+					fqdn="testhostname.test.com"
 					ip_addr="10.0.0.12"
 					enable_dns = "true"
 					comment = "10.0.0.12 IP is allocated"
@@ -160,7 +160,7 @@ func TestAcc_resourceipAssociation_ipv4(t *testing.T) {
 					&ibclient.HostRecord{
 						NetworkView: "default",
 						View:        "default",
-						Name:        "testhostname.aws.com",
+						Name:        "testhostname.test.com",
 						Ipv4Addr:    "10.0.0.12",
 						Comment:     "10.0.0.12 IP is associated",
 						Ea: ibclient.EA{
@@ -186,7 +186,7 @@ func TestAcc_resourceIPAssociation_ipv6(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "infoblox_ipv6_allocation" "ipv6_allocation" {
 					network_view= "default"
-					fqdn="testhostnameipv6.aws.com"
+					fqdn="testhostnameipv6.test.com"
 					ip_addr = "2001:db8:abcd:12::10"
 					duid = "00:00:00:00:00:00:00:10"
 					comment = "tf IPv6 allocation"
@@ -217,7 +217,7 @@ func TestAcc_resourceIPAssociation_ipv6(t *testing.T) {
 					&ibclient.HostRecord{
 						NetworkView: "default",
 						View:        "default",
-						Name:        "testhostnameipv6.aws.com",
+						Name:        "testhostnameipv6.test.com",
 						Ipv6Addr:    "2001:db8:abcd:12::10",
 						Comment:     "2001:db8:abcd:12::10 IP is associated",
 						Ea: ibclient.EA{

--- a/infoblox/resource_infoblox_ptr_record_test.go
+++ b/infoblox/resource_infoblox_ptr_record_test.go
@@ -12,8 +12,8 @@ import (
 var testAccresourceRecordPTRCreate = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo"{
     dns_view="default"
-	ptrdname="testPtrdName.aws.com"
-	record_name="testName.aws.com"
+	ptrdname="testPtrdName.test.com"
+	record_name="testName.test.com"
 	comment="PTR record created in forward mapping zone"
 	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
@@ -27,7 +27,7 @@ var testAccresourceRecordPTRCreate_2 = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo2"{
 	network_view="default"
     dns_view="default"
-	ptrdname="testPtrdName2.aws.com"
+	ptrdname="testPtrdName2.test.com"
 	ip_addr = "10.0.0.2"
 	comment="PTR record created in reverse mapping zone with IP"
 	ext_attrs=jsonencode({
@@ -41,8 +41,8 @@ resource "infoblox_ptr_record" "foo2"{
 var testAccresourceRecordPTRUpdate = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo"{
 	dns_view="default"
-	ptrdname="testPtrdName.aws.com"
-	record_name="testName.aws.com"
+	ptrdname="testPtrdName.test.com"
+	record_name="testName.test.com"
 	comment="PTR record created in forward mapping zone"
 	ext_attrs = jsonencode({
 		"Tenant ID" = "terraform_test_tenant"
@@ -56,7 +56,7 @@ var testAccresourceRecordPTRUpdate_2 = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo2"{
 	network_view = "default"
 	dns_view="default"
-	ptrdname="testPtrdName2.aws.com"
+	ptrdname="testPtrdName2.test.com"
 	ip_addr = "10.0.0.2"
 	comment="PTR record created in reverse mapping zone with IP"
 	ext_attrs = jsonencode({
@@ -163,9 +163,9 @@ func TestAcc_resourceRecordPTR(t *testing.T) {
 					"infoblox_ptr_record.foo",
 					&ibclient.RecordPTR{
 						View:     "default",
-						PtrdName: "testPtrdName.aws.com",
+						PtrdName: "testPtrdName.test.com",
 						Name:     "testName",
-						Zone:     "aws.com",
+						Zone:     "test.com",
 						Comment:  "PTR record created in forward mapping zone",
 						Ea: ibclient.EA{
 							"Tenant ID": "terraform_test_tenant",
@@ -182,9 +182,9 @@ func TestAcc_resourceRecordPTR(t *testing.T) {
 					"infoblox_ptr_record.foo",
 					&ibclient.RecordPTR{
 						View:     "default",
-						PtrdName: "testPtrdName.aws.com",
+						PtrdName: "testPtrdName.test.com",
 						Name:     "testName",
-						Zone:     "aws.com",
+						Zone:     "test.com",
 						Comment:  "PTR record created in forward mapping zone",
 						Ea: ibclient.EA{
 							"Tenant ID": "terraform_test_tenant",
@@ -201,7 +201,7 @@ func TestAcc_resourceRecordPTR(t *testing.T) {
 					"infoblox_ptr_record.foo2",
 					&ibclient.RecordPTR{
 						View:     "default",
-						PtrdName: "testPtrdName2.aws.com",
+						PtrdName: "testPtrdName2.test.com",
 						Ipv4Addr: "10.0.0.2",
 						Comment:  "PTR record created in reverse mapping zone with IP",
 						Ea: ibclient.EA{
@@ -219,7 +219,7 @@ func TestAcc_resourceRecordPTR(t *testing.T) {
 					"infoblox_ptr_record.foo2",
 					&ibclient.RecordPTR{
 						View:     "default",
-						PtrdName: "testPtrdName2.aws.com",
+						PtrdName: "testPtrdName2.test.com",
 						Ipv4Addr: "10.0.0.2",
 						Comment:  "PTR record created in reverse mapping zone with IP",
 						Ea: ibclient.EA{


### PR DESCRIPTION
With this PR we are a uniform zone across  the UTs. `test.com` is the zone which needs to be created while running the UTs.