### PR TITLE
association with host record bug fix

### DIFF
--- a/infoblox/resource_infoblox_ip_association_legacy.go
+++ b/infoblox/resource_infoblox_ip_association_legacy.go
@@ -368,7 +368,7 @@ func resourceIPv6AssociationDelete(d *schema.ResourceData, m interface{}) error 
 }
 
 func resourceIPv6AssociationInit() *schema.Resource {
-	ipv6Association := resourceIpAssociation()
+	ipv6Association := resourceIpAssoc()
 	ipv6Association.Create = resourceIPv6AssociationCreate
 	ipv6Association.Read = resourceIPv6AssociationRead
 	ipv6Association.Update = resourceIPv6AssociationUpdate


### PR DESCRIPTION
`infoblox_ipv6_association` resource is expecting `infoblox_ip_association` resource parameters. Correcting the same.