### PR TITLE
Disabled cli input for the password provider parameter

### DIFF
--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -70,7 +70,7 @@ func Provider() *schema.Provider {
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("INFOBLOX_PASSWORD", nil),
 				Description: "Password to authenticate with Infoblox server.",
 			},
@@ -137,6 +137,13 @@ func Provider() *schema.Provider {
 func providerConfigure(
 	ctx context.Context,
 	d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+
+	if d.Get("password") == "" {
+		return nil, diag.Diagnostics{diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Export the required INFOBLOX_PASSWORD environment variable to set the password.",
+		}}
+	}
 
 	seconds := int64(d.Get("connect_timeout").(int))
 	hostConfig := ibclient.HostConfig{


### PR DESCRIPTION
# Issue/Feature description

* When the user doesn't export the `INFOBLOX_PASSWORD` env var, the terraform client is prompting the user for input, which 
  is not hidden in any way.

* We decided to disable the cli input to reduce the chance of the password gets compromised.

* Related terraform issue: https://github.com/hashicorp/terraform/issues/29609

# How it was fixed/implemented

* Made the password parameter optional.

* providerConfigure function will raise an error if password parameter is
  not set.

* This way, terraform cli will not ask a user for the password.

* Now, the only two ways to set the API key parameter is to export `INFOBLOX_PASSWORD` env var, or to [configure the 'password' 
  parameter](https://www.terraform.io/language/providers/configuration#provider-configuration-1) in the provider configuration section of the terraform root `.tf` module.