### PR TITLE
changing default config for a tag creation with GitHub action

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -20,5 +20,5 @@ jobs:
     - uses: anothrNick/github-tag-action@1.35.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DEFAULT_BUMP: patch
+        DEFAULT_BUMP: none
         WITH_V: true


### PR DESCRIPTION
**Solution proposed**
Changing the default setting to `none` can help not creating a tag until unless there is a release planned by the respective development team.  The reference of configurations can be found [at](https://github.com/anothrNick/github-tag-action#bumping). 