### PR TITLE
Add infoblox_zone_delegated resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ There are resources for the following objects, supported by the plugin:
 -   PTR-record
 -   CNAME-record
 -   Host record
+-   Zone delegated
 
 Network container and network resources have two versions: IPv4 and IPv6. In
 addition, there are two operations which are implemented as resources:

--- a/docs/resources/infoblox_zone_delegated.md
+++ b/docs/resources/infoblox_zone_delegated.md
@@ -1,0 +1,39 @@
+# Resource Zone Delegated
+
+A Zone Delegated resource creates NS records for a subdomain, pointing to one or more external authoritative name servers. The `infoblox_zone_delegated` resource allow managing such delegations. The parent zone must already exist 
+
+The following list describes the parameters you can define in the `infoblox_zone_delegated` resource block:
+
+## Argument Reference
+* `fqdn`: (Required) The subdomain name to be delegated
+* `delegate_to`: (Required) Nested block(s)s for the delegated name servers
+    * `address`: (Required) The IP address of the name server
+    * `name`: (Required) The FQDN of the name server
+* `ext_attrs`: (Optional) A set of NIOS extensible attributes that are attached to the record, using jsonencode. Currently only "Tenant ID" is supported
+
+## Example Usage
+
+```hcl
+resource "infoblox_zone_delegated" "subdomain" {
+
+  fqdn = "subdomain.test.com"
+
+  delegate_to {
+    address = "205.251.197.208"
+    name = "ns-1488.awsdns-58.org"
+  }
+
+  delegate_to {
+    address = "205.251.199.242"
+    name = "ns-2034.awsdns-62.co.uk"
+  }
+
+}
+```
+
+## Import
+Zone Delegated resources can be imported by using either the object reference or the subdomain fqdn, for example:
+```shell script
+# terraform import infoblox_zone_delegated.subdomain zone_delegated/ZG5zLnpvbmUkLl9kZWZhdWx0LmNvbS5jb2xsZWdlY2hvaWNldHJhbnNpdGlvbi5nc2xi:subdomain.test.com/default
+# terraform import infoblox_zone_delegated.subdomain subdomain.test.com
+```

--- a/examples/v0.14/Resources/ZoneDelegated/infoblox.tf
+++ b/examples/v0.14/Resources/ZoneDelegated/infoblox.tf
@@ -1,0 +1,17 @@
+# Zone Delegated
+
+resource "infoblox_zone_delegated" "subdomain" {
+
+  fqdn = "subdomain.example.com"
+
+  delegate_to {
+    address = "205.251.197.208"
+    name = "ns-1488.awsdns-58.org"
+  }
+
+  delegate_to {
+    address = "205.251.199.242"
+    name = "ns-2034.awsdns-62.co.uk"
+  }
+
+}

--- a/examples/v0.14/Resources/ZoneDelegated/versions.tf
+++ b/examples/v0.14/Resources/ZoneDelegated/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    infoblox = {
+      source = "infobloxopen/infoblox"
+      version = ">= 2.1"
+    }
+  }
+}

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -123,6 +123,7 @@ func Provider() *schema.Provider {
 			"infoblox_aaaa_record":            resourceAAAARecord(),
 			"infoblox_cname_record":           resourceCNAMERecord(),
 			"infoblox_ptr_record":             resourcePTRRecord(),
+			"infoblox_zone_delegated":         resourceZoneDelegated(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"infoblox_ipv4_network": dataSourceIPv4Network(),

--- a/infoblox/resource_infoblox_zone_delegated.go
+++ b/infoblox/resource_infoblox_zone_delegated.go
@@ -1,0 +1,229 @@
+package infoblox
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+)
+
+func resourceZoneDelegated() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceZoneDelegatedCreate,
+		Read:   resourceZoneDelegatedRead,
+		Update: resourceZoneDelegatedUpdate,
+		Delete: resourceZoneDelegatedDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"fqdn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The FQDN of the delegated zone.",
+			},
+			"delegate_to": resourceNameServer(),
+			"ext_attrs": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "Extensible attributes, as a map in JSON format",
+			},
+		},
+	}
+}
+
+func resourceNameServer() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Required: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"address": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "IP of Name Server",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "FQDN of Name Server",
+				},
+			},
+		},
+	}
+}
+
+func resourceZoneDelegatedCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning to create Zone Delegated", resourceZoneDelegatedIDString(d))
+
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs := make(map[string]interface{})
+	if extAttrJSON != "" {
+		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
+		}
+	}
+
+	delegatedFQDN := d.Get("fqdn").(string)
+
+	var nameServers []ibclient.NameServer
+	delegations := d.Get("delegate_to").(*schema.Set).List()
+	for _, delegation := range delegations {
+		var ns ibclient.NameServer
+		var delegationMap = delegation.(map[string]interface{})
+		ns.Address = delegationMap["address"].(string)
+		ns.Name = delegationMap["name"].(string)
+		nameServers = append(nameServers, ns)
+	}
+
+	var tenantID string
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
+	}
+
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	zoneDelegated, err := objMgr.CreateZoneDelegated(
+		delegatedFQDN,
+		nameServers)
+	if err != nil {
+		return fmt.Errorf("Error creating Zone Delegated: %s", err)
+	}
+
+	d.SetId(zoneDelegated.Ref)
+
+	log.Printf("[DEBUG] %s: Creation of Zone Delegated complete", resourceZoneDelegatedIDString(d))
+	return nil
+}
+
+func resourceZoneDelegatedRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Begining to Get Zone Delegated", resourceZoneDelegatedIDString(d))
+
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs := make(map[string]interface{})
+	if extAttrJSON != "" {
+		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
+		}
+	}
+
+	var tenantID string
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
+	}
+
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	// first attempt to read by ref, otherwise assume import and support fqdn
+	zoneDelegatedObj, err := objMgr.GetZoneDelegatedByRef(d.Id())
+	if err != nil {
+		zoneDelegatedObj, err = objMgr.GetZoneDelegated(d.Id())
+		if err != nil {
+			return fmt.Errorf("Getting Zone Delegated failed: %s", err)
+		}
+	}
+
+	var delegations []map[string]interface{}
+	for _, delegation := range zoneDelegatedObj.DelegateTo {
+		ns := make(map[string]interface{})
+		ns["address"] = delegation.Address
+		ns["name"] = delegation.Name
+		delegations = append(delegations, ns)
+	}
+
+	d.Set("fqdn", zoneDelegatedObj.Fqdn)
+	d.Set("delegate_to", delegations)
+
+	d.SetId(zoneDelegatedObj.Ref)
+
+	log.Printf("[DEBUG] %s: Completed reading Zone Delegated ", resourceZoneDelegatedIDString(d))
+	return nil
+}
+
+func resourceZoneDelegatedUpdate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning to update Zone Delegated", resourceZoneDelegatedIDString(d))
+
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs := make(map[string]interface{})
+	if extAttrJSON != "" {
+		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
+		}
+	}
+
+	var nameServers []ibclient.NameServer
+	delegations := d.Get("delegate_to").(*schema.Set).List()
+	for _, delegation := range delegations {
+		var ns ibclient.NameServer
+		var delegationMap = delegation.(map[string]interface{})
+		ns.Address = delegationMap["address"].(string)
+		ns.Name = delegationMap["name"].(string)
+		nameServers = append(nameServers, ns)
+	}
+
+	var tenantID string
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
+	}
+
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	zoneDelegatedUpdated, err := objMgr.UpdateZoneDelegated(d.Id(), nameServers)
+	if err != nil {
+		return fmt.Errorf("Updating of Zone Delegated failed : %s", err.Error())
+	}
+
+	d.SetId(zoneDelegatedUpdated.Ref)
+	return nil
+}
+
+func resourceZoneDelegatedDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning Deletion of Zone Delegated", resourceZoneDelegatedIDString(d))
+
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs := make(map[string]interface{})
+	if extAttrJSON != "" {
+		if err := json.Unmarshal([]byte(extAttrJSON), &extAttrs); err != nil {
+			return fmt.Errorf("cannot process 'ext_attrs' field: %s", err.Error())
+		}
+	}
+
+	var tenantID string
+	if tempVal, ok := extAttrs["Tenant ID"]; ok {
+		tenantID = tempVal.(string)
+	}
+
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	_, err := objMgr.DeleteZoneDelegated(d.Id())
+	if err != nil {
+		return fmt.Errorf("Deletion of Zone Delegated failed : %s", err)
+	}
+	d.SetId("")
+
+	log.Printf("[DEBUG] %s: Deletion of Zone Delegated complete", resourceZoneDelegatedIDString(d))
+	return nil
+}
+
+type resourceZoneDelegatedIDStringInterface interface {
+	Id() string
+}
+
+func resourceZoneDelegatedIDString(d resourceZoneDelegatedIDStringInterface) string {
+	id := d.Id()
+	if id == "" {
+		id = "<new resource>"
+	}
+	return fmt.Sprintf("infoblox_zone_delegated (ID = %s)", id)
+}

--- a/infoblox/resource_infoblox_zone_delegated_test.go
+++ b/infoblox/resource_infoblox_zone_delegated_test.go
@@ -1,0 +1,92 @@
+package infoblox
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+)
+
+func testAccCheckZoneDelegatedDestroy(s *terraform.State) error {
+	meta := testAccProvider.Meta()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "infoblox_zone_delegated" {
+			return fmt.Errorf("Resource type %s is invalid after destroy", rs.Type)
+		}
+		connector := meta.(ibclient.IBConnector)
+		objMgr := ibclient.NewObjectManager(connector, "terraform_test", "test")
+		rec, _ := objMgr.GetZoneDelegatedByRef(rs.Primary.ID)
+		if rec != nil {
+			return fmt.Errorf("Zone Delegation record found after destroy")
+		}
+	}
+	return nil
+}
+
+func testAccZoneDelegatedCompare(t *testing.T, resPath string, expectedRec *ibclient.RecordNS) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, found := s.RootModule().Resources[resPath]
+		if !found {
+			return fmt.Errorf("Not found: %s", resPath)
+		}
+		if res.Primary.ID == "" {
+			return fmt.Errorf("ID is not set")
+		}
+		meta := testAccProvider.Meta()
+		connector := meta.(ibclient.IBConnector)
+		objMgr := ibclient.NewObjectManager(connector, "terraform_test", "test")
+
+		rec, _ := objMgr.GetZoneDelegatedByRef(res.Primary.ID)
+		if rec == nil {
+			return fmt.Errorf("record not found")
+		}
+
+		if rec.Fqdn != expectedRec.Name {
+			return fmt.Errorf(
+				"'fqdn' does not match: got '%s', expected '%s'",
+				rec.Fqdn, expectedRec.Name)
+		}
+		if rec.DelegateTo[0].Address != expectedRec.Addresses[0].Address {
+			return fmt.Errorf(
+				"'delegate_to['address']' does not match: got '%s', expected '%s'",
+				rec.DelegateTo[0].Address, expectedRec.Addresses[0].Address)
+		}
+		if rec.DelegateTo[0].Name != expectedRec.Nameserver {
+			return fmt.Errorf(
+				"'delegate_to['name']' does not match: got '%s', expected '%s'",
+				rec.DelegateTo[0].Name, expectedRec.Nameserver)
+		}
+		return nil
+	}
+}
+
+func TestAccResourceZoneDelegated(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckZoneDelegatedDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+						resource "infoblox_zone_delegated" "foo"{
+							fqdn="subdomain.test.com"
+							delegate_to {
+								address = "1.2.3.4"
+								name = "dns.test.com"
+							}
+							}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccZoneDelegatedCompare(t, "infoblox_zone_delegated.foo", &ibclient.RecordNS{
+						Name:       "subdomain.test.com",
+						Addresses:  []ibclient.ZoneNameServer{ibclient.ZoneNameServer{Address: "1.2.3.4"}},
+						Nameserver: "dns.test.com",
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Add a new resource to support Zone Delegation

Features:
- CRUD and Import supported
- Acceptance test 
- Documentation and examples

Caveats:
- Only tested with on-prem NIOS
- No support for dns_view or ext_attrs in the golang API client for ZoneDelegation
- Depends on infobloxopen/infoblox-go-client/pull/172 for GetZoneDelegatedByRef