### PR TITLE
Fixes no error thrown when there is change in 'cidr' value

### DIFF
--- a/infoblox/resource_infoblox_network_container.go
+++ b/infoblox/resource_infoblox_network_container.go
@@ -198,6 +198,10 @@ func resourceNetworkContainerUpdate(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
 	}
 
+	if d.HasChange("cidr") {
+		return fmt.Errorf("changing the value of 'cidr' field is not allowed")
+	}
+
 	if d.HasChange("parent_cidr") {
 		return fmt.Errorf("changing the value of 'parent_cidr' field is not allowed")
 	}


### PR DESCRIPTION
This PR contains bug fix for next available network container, code was not throwing an error, if the cidr value is being changed. 