### PR TITLE
Adds test cases and fixes no error is thrown for 'cidr' changes

### DIFF
--- a/infoblox/resource_infoblox_network_container.go
+++ b/infoblox/resource_infoblox_network_container.go
@@ -198,6 +198,10 @@ func resourceNetworkContainerUpdate(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("changing the value of 'network_view' field is not allowed")
 	}
 
+	if d.HasChange("cidr") {
+		return fmt.Errorf("changing the value of 'cidr' field is not allowed")
+	}
+
 	if d.HasChange("parent_cidr") {
 		return fmt.Errorf("changing the value of 'parent_cidr' field is not allowed")
 	}

--- a/infoblox/resource_infoblox_network_container_test.go
+++ b/infoblox/resource_infoblox_network_container_test.go
@@ -260,6 +260,20 @@ func TestAcc_resourceNetworkContainer_ipv4(t *testing.T) {
 			},
 			{
 				Config: `
+					resource "infoblox_ipv4_network_container" "nc_2" {
+					  network_view = "default"
+					  cidr = "25.0.10.0/24"
+					  comment = "25.0.0.0/24 network container"
+					  ext_attrs = jsonencode({
+						"Tenant ID" = "terraform_test_tenant"
+						Location = "Test location"
+						Site = "Test site"
+					  })
+					}`,
+				ExpectError: updateNotAllowedRegexp,
+			},
+			{
+				Config: `
 					resource "infoblox_network_view" "nv1" {
 						name = "non_default_view_54397156"
 					}
@@ -456,6 +470,19 @@ func TestAcc_resourceNetworkContainer_ipv6(t *testing.T) {
 					  parent_cidr = infoblox_ipv6_network_container.nc6_2.cidr
 					  allocate_prefix_len = 59
 					  comment = "dynamic network container testing"
+					  ext_attrs = jsonencode({
+						"Tenant ID" = "terraform_test_tenant"
+						Site = "Test site"
+					  })
+					}`,
+				ExpectError: updateNotAllowedRegexp,
+			},
+			{
+				Config: `
+					resource "infoblox_ipv6_network_container" "nc6_2" {
+					  network_view = "default"
+					  cidr = "fc02::/56"
+					  comment = "fc01::/56 network container"
 					  ext_attrs = jsonencode({
 						"Tenant ID" = "terraform_test_tenant"
 						Site = "Test site"


### PR DESCRIPTION
This adds both test cases to test that error is thrown for `cidr` value changes,  and fixes no error is thrown for `cidr` changes. 
This has additional commit than the PR #300