### PR TITLE
Fixes unable to update ip address of A record dynamically

### DIFF
--- a/docs/resources/infoblox_a_record.md
+++ b/docs/resources/infoblox_a_record.md
@@ -15,6 +15,9 @@ The following list describes the parameters you can define in the resource block
     * For allocating a dynamic IP address, configure the `cidr` field instead of `ip_addr` . Optionally, specify a `network_view` if you do not want to allocate it in the network view `default`.
 * `cidr`: required only for dynamic allocation, specifies the network from which to allocate an IP address when the `ip_addr` field is empty. The address is in CIDR format. For static allocation, use `ip_addr` instead of `cidr`. Example: `192.168.10.4/30`.
 
+!> In running the `.tf` files, if you want to use the uppercase letters in `fqdn`, please consider using `lower()`
+as it is creating inconsistency here in the `.tfstate` file and in NIOS grid. For this note , an example is added.
+
 ### Examples of an A-record Block
 
 ```hcl

--- a/docs/resources/infoblox_a_record.md
+++ b/docs/resources/infoblox_a_record.md
@@ -15,8 +15,7 @@ The following list describes the parameters you can define in the resource block
     * For allocating a dynamic IP address, configure the `cidr` field instead of `ip_addr` . Optionally, specify a `network_view` if you do not want to allocate it in the network view `default`.
 * `cidr`: required only for dynamic allocation, specifies the network from which to allocate an IP address when the `ip_addr` field is empty. The address is in CIDR format. For static allocation, use `ip_addr` instead of `cidr`. Example: `192.168.10.4/30`.
 
-!> In running the `.tf` files, if you want to use the uppercase letters in `fqdn`, please consider using `lower()`
-as it is creating inconsistency here in the `.tfstate` file and in NIOS grid. For this note , an example is added.
+!> While updating A Record name with uppercase letters, please consider using lower function. Example: `lower(testEXAMPLE.zone1.com)`.
 
 ### Examples of an A-record Block
 

--- a/examples/resources/infoblox_a_record.tf
+++ b/examples/resources/infoblox_a_record.tf
@@ -26,3 +26,13 @@ resource "infoblox_a_record" "rec3" {
   ttl = 0 // 0 = disable caching
   ext_attrs = jsonencode({})
 }
+
+// name parameter recommended to use with lower() function
+resource "infoblox_a_record" "rec4" {
+  fqdn = lower("NEWRECORD2.example2.org") // if you want to use uppercase letters, please use this 'lower' function
+  cidr = "25.10.0.0/24"
+  network_view = "default"
+  dns_view = "nondefault_dnsview2"
+  ttl = 0 // 0 = disable caching
+  ext_attrs = jsonencode({})
+}

--- a/examples/resources/infoblox_a_record.tf
+++ b/examples/resources/infoblox_a_record.tf
@@ -28,11 +28,12 @@ resource "infoblox_a_record" "rec3" {
 }
 
 // name parameter recommended to use with lower() function
-resource "infoblox_a_record" "rec4" {
-  fqdn = lower("NEWRECORD2.example2.org") // if you want to use uppercase letters, please use this 'lower' function
-  cidr = "25.10.0.0/24"
-  network_view = "default"
-  dns_view = "nondefault_dnsview2"
+resource "infoblox_a_record" "rec3" {
+  fqdn = lower("dynaMIC1.example2.org") // if you want to use uppercase letters, please use this 'lower' function
+  cidr = infoblox_ipv4_network.net2.cidr // the network  must exist, you may use the example for infoblox_ipv4_network resource.
+  network_view = infoblox_ipv4_network.net2.network_view // not necessarily in the same network view as the DNS view resides in.
+  comment = "example dynamic A-record rec3"
+  dns_view = "nondefault_dnsview1"
   ttl = 0 // 0 = disable caching
   ext_attrs = jsonencode({})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
-	github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230525121944-7aeeca0ab3b7
+	github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0
 	github.com/sirupsen/logrus v1.8.0
 )
 
@@ -70,3 +70,5 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
+
+replace github.com/infobloxopen/infoblox-go-client/v2 => ../infoblox-go-client

--- a/go.mod
+++ b/go.mod
@@ -70,5 +70,3 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
-
-replace github.com/infobloxopen/infoblox-go-client/v2 => ../infoblox-go-client

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0 h1:g6fytbdP9DV4eN+8Mi1JXnT8F3oJTkupa+yS60lzHEk=
+github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0/go.mod h1:ZR191VH7ccpUZ+dzjALQorTevLPv+1P9N62TGJ87ib0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230525121944-7aeeca0ab3b7 h1:3VFBeDEUKK4JFohYCIbhaSHgdOcpV33c/RFHtdhNCxY=
-github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230525121944-7aeeca0ab3b7/go.mod h1:ZR191VH7ccpUZ+dzjALQorTevLPv+1P9N62TGJ87ib0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/infoblox/resource_infoblox_a_record.go
+++ b/infoblox/resource_infoblox_a_record.go
@@ -262,6 +262,16 @@ func resourceARecordUpdate(d *schema.ResourceData, m interface{}) error {
 		cidr = ""
 	}
 
+	if !d.HasChange("cidr") && d.HasChange("ip_addr") {
+		return fmt.Errorf("allowing 'ip_addr' to update creates inconsistency with 'cidr'")
+	}
+
+	// this will fix issue when 'cidr' given for update when 'ip_addr' already
+	// exists in the state, unable to update value of ip_addr in NIOS with given 'cidr'.
+	if d.HasChange("cidr") && ipAddr != "" {
+		ipAddr = ""
+	}
+
 	var ttl uint32
 	useTtl := false
 	tempVal := d.Get("ttl")

--- a/infoblox/resource_infoblox_a_record.go
+++ b/infoblox/resource_infoblox_a_record.go
@@ -262,10 +262,6 @@ func resourceARecordUpdate(d *schema.ResourceData, m interface{}) error {
 		cidr = ""
 	}
 
-	if !d.HasChange("cidr") && d.HasChange("ip_addr") {
-		return fmt.Errorf("allowing 'ip_addr' to update creates inconsistency with 'cidr'")
-	}
-
 	// this will fix issue when 'cidr' given for update when 'ip_addr' already
 	// exists in the state, unable to update value of ip_addr in NIOS with given 'cidr'.
 	if d.HasChange("cidr") && ipAddr != "" {

--- a/infoblox/resource_infoblox_a_record_test.go
+++ b/infoblox/resource_infoblox_a_record_test.go
@@ -170,6 +170,46 @@ func TestAccResourceARecord(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					resource "infoblox_a_record" "foo3"{
+						fqdn = "newsample.test.com"
+						ip_addr = "10.10.0.3"
+						ttl = 100
+						dns_view = "nondefault_view"
+						comment = "test comment 2"
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccARecordCompare(t, "infoblox_a_record.foo3", &ibclient.RecordA{
+						Ipv4Addr: "10.10.0.3",
+						Name:     "newsample.test.com",
+						View:     "nondefault_view",
+						UseTtl:   true,
+						Ttl:      100,
+						Comment:  "test comment 2",
+					}),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "infoblox_a_record" "foo3"{
+						fqdn = lower("newSAMPLE2.test.com")
+						ip_addr = "10.10.0.3"
+						ttl = 100
+						dns_view = "nondefault_view"
+						comment = "test comment 2"
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccARecordCompare(t, "infoblox_a_record.foo3", &ibclient.RecordA{
+						Ipv4Addr: "10.10.0.3",
+						Name:     "newsample2.test.com",
+						View:     "nondefault_view",
+						UseTtl:   true,
+						Ttl:      100,
+						Comment:  "test comment 2",
+					}),
+				),
+			},
 		},
 	})
 }

--- a/infoblox/resource_infoblox_a_record_test.go
+++ b/infoblox/resource_infoblox_a_record_test.go
@@ -52,6 +52,15 @@ func testAccARecordCompare(t *testing.T, resPath string, expectedRec *ibclient.R
 				rec.Name,
 				expectedRec.Name)
 		}
+
+		if expectedRec.Ipv4Addr == "" {
+			expectedRec.Ipv4Addr = res.Primary.Attributes["ip_addr"]
+			if expectedRec.Ipv4Addr == "" {
+				return fmt.Errorf(
+					"the value of 'ip_addr' field is empty, but expected some value")
+			}
+		}
+
 		if rec.Ipv4Addr != expectedRec.Ipv4Addr {
 			return fmt.Errorf(
 				"'ipv4address' does not match: got '%s', expected '%s'",

--- a/vendor/github.com/infobloxopen/infoblox-go-client/v2/object_manager_a-record.go
+++ b/vendor/github.com/infobloxopen/infoblox-go-client/v2/object_manager_a-record.go
@@ -76,7 +76,7 @@ func (objMgr *ObjectManager) UpdateARecord(
 	comment string,
 	eas EA) (*RecordA, error) {
 
-	cleanName := strings.ToLower(strings.TrimSpace(name))
+	cleanName := strings.TrimSpace(name)
 	if cleanName == "" || cleanName != name {
 		return nil, fmt.Errorf(
 			"'name' argument is expected to be non-empty and it must NOT contain leading/trailing spaces")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0 => ../infoblox-go-client
+# github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0
 ## explicit; go 1.17
 github.com/infobloxopen/infoblox-go-client/v2
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -446,4 +446,3 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
-# github.com/infobloxopen/infoblox-go-client/v2 => ../infoblox-go-client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230525121944-7aeeca0ab3b7
+# github.com/infobloxopen/infoblox-go-client/v2 v2.3.1-0.20230612083744-3ef0d7777db0 => ../infoblox-go-client
 ## explicit; go 1.17
 github.com/infobloxopen/infoblox-go-client/v2
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -446,3 +446,4 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
+# github.com/infobloxopen/infoblox-go-client/v2 => ../infoblox-go-client


### PR DESCRIPTION
This PR contains both fixes below:
- If user wants particularly to give uppercase letters in the A record name, then it was creating inconsistency, this contains fix for this.
- Another fix , unable to update the ip address of A record , with updating `cidr` value(dynamically).