### PR TITLE
Manage ext_attrs for NULL value and State File

### DIFF
--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -286,6 +286,7 @@ func filterFromMap(filtersMap map[string]interface{}) map[string]string {
 // terraformSerializeEAs will convert ibclient.EA to a JSON-formatted string,
 // which is generally used as a value for 'ext_attrs' terraform fields.
 func terraformSerializeEAs(ea ibclient.EA) (string, error) {
+	delete(ea, eaNameForInternalId)
 	eaMap := (map[string]interface{})(ea)
 	eaJSON, err := json.Marshal(eaMap)
 	if err != nil {
@@ -304,7 +305,9 @@ func terraformDeserializeEAs(extAttrJSON string) (map[string]interface{}, error)
 			return nil, fmt.Errorf("cannot process 'ext_attrs' field: %w", err)
 		}
 	}
-
+	if extAttrs == nil {
+		extAttrs = make(map[string]interface{})
+	}
 	return extAttrs, nil
 }
 

--- a/infoblox/resource_infoblox_network_view.go
+++ b/infoblox/resource_infoblox_network_view.go
@@ -136,7 +136,7 @@ func resourceNetworkViewRead(d *schema.ResourceData, m interface{}) error {
 	if !networkViewRegExp.MatchString(nv.Ref) {
 		return fmt.Errorf("reference '%s' for 'networkview' object has an invalid format", nv.Ref)
 	}
-	delete(nv.Ea, eaNameForTenantId)
+	delete(nv.Ea, eaNameForInternalId)
 	omittedEAs := omitEAs(nv.Ea, extAttrs)
 
 	if omittedEAs != nil && len(omittedEAs) > 0 {


### PR DESCRIPTION
[FIX] Handle ext_attrs from panic when Null, Network view ext_attrs idempotent for each apply.
[IMP] Remove "Terraform Internal ID" from the ext_attrs from state file.