### PR TITLE
Improve formatting of docs and code-examples

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,38 +1,43 @@
 # Developing the Provider Plugin
-Contribution to the plugin can be done at various levels and we would embrace it. 
+
+Contribution to the plugin can be done at various levels and we would embrace it.
 
 Working at code level requires you  to set up the environment, clone the code, build, and test the code.
 
 ## Building the Binary from Source Code and Using it
+
 Golang and Terraform installed in the system are basic requirements to build and test the plugin.
 
 * Install and set up Golang  version 1.21 or later from:
   `https://golang.org/doc/install`
-* Install Terraform CLI v1.8.1+ from:  
+* Install Terraform CLI v1.8.1+ from:
   `https://www.terraform.io/downloads.html`
 * Clone the repo and build it as follows:
+
   ```
-    $ cd `go env GOPATH`/src
-    $ mkdir -p github.com/infobloxopen
-    $ cd github.com/infobloxopen
-    $ git clone https://github.com/infobloxopen/terraform-provider-infoblox
-    $ cd terraform-provider-infoblox
-    $ make build
-  ```  
-  
+    cd `go env GOPATH`/src
+    mkdir -p github.com/infobloxopen
+    cd github.com/infobloxopen
+    git clone https://github.com/infobloxopen/terraform-provider-infoblox
+    cd terraform-provider-infoblox
+    make build
+  ```
+
 * To install the resulting binary as a plugin, follow the instructions on page:
   `https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers`
 
 ## Testing the Provider
+
 To run the full suite of acceptance tests, run the following commands:
+
   ```
-    $ export INFOBLOX_SERVER=<nios_ip-addr> or <hostname>
-    $ export INFOBLOX_USERNAME=<nios_username>
-    $ export INFOBLOX_PASSWORD=<nios_password>
-    $ make test
-    $ export TF_ACC=true # without this only unit tests (not acceptance tests) run
-    $ make testacc
+    export INFOBLOX_SERVER=<nios_ip-addr> or <hostname>
+    export INFOBLOX_USERNAME=<nios_username>
+    export INFOBLOX_PASSWORD=<nios_password>
+    make test
+    export TF_ACC=true # without this only unit tests (not acceptance tests) run
+    make testacc
   ```
 
-Refer to the comments included in the code for running the tests, and make sure that the mentioned conditions are met. 
+Refer to the comments included in the code for running the tests, and make sure that the mentioned conditions are met.
 For example, you may have to create objects such as DNS zones and views before running the tests.

--- a/GETTING.md
+++ b/GETTING.md
@@ -1,58 +1,66 @@
 
 # Getting the provider plugin
+
 There are two ways of getting the plugin and using it:
 
 * Use the published provider plugin from the Terraform registry: You do not need to do anything special, the plugin will be installed by Terraform automatically once it is mentioned as a requirement in your .tf files.
 * Build from GitHub repository source code: This way is suitable for those who want to introduce some customizations or get the latest features under development, which are not in the official plugin yet.
 
 ## Getting it from the Terraform Official Registry
+
 Specify the plugin version in the .tf file as follows:
-  ```
-    terraform {
-      required_providers {
-        infoblox = {
-          source = "infobloxopen/infoblox"
-          version = ">= 2.7.0"
-        }
+
+```hcl
+  terraform {
+    required_providers {
+      infoblox = {
+        source = "infobloxopen/infoblox"
+        version = ">= 2.7.0"
       }
     }
+  }
 
-    provider "infoblox" {
-      # Configuration options
-      server = "nios_ip-addr"
-      username = "username"
-      password = "password"
-    }
-  ```
+  provider "infoblox" {
+    # Configuration options
+    server = "nios_ip-addr"
+    username = "username"
+    password = "password"
+  }
+```
 
 Configure the credentials as environment variables as follows:
-  ```
-    $ export INFOBLOX_SERVER=<nios_ip-addr> or <hostname>
-    $ export INFOBLOX_USERNAME=<nios_username>
-    $ export INFOBLOX_PASSWORD=<nios_password>
-  ```
+
+```shell
+  export INFOBLOX_SERVER=<nios_ip-addr> or <hostname>
+  export INFOBLOX_USERNAME=<nios_username>
+  export INFOBLOX_PASSWORD=<nios_password>
+```
 
 Terraform installs the specified version of the plugin when a `terraform init` is run.
 
-Refer to the official documentation for more information https://registry.terraform.io/providers/infobloxopen/infoblox/latest/docs .
+Refer to the official documentation for more information <https://registry.terraform.io/providers/infobloxopen/infoblox/latest/docs> .
 
 ## Building a Binary from the GitHub Source Code and Using it
+
 Complete the following steps to build the binary:
+
 * Install and set up Golang  version 1.21 or later from:
   `https://golang.org/doc/install`
-* Install Terraform CLI v1.8.1+ from:  
+* Install Terraform CLI v1.8.1+ from:
   `https://www.terraform.io/downloads.html`
 * Clone the repo and build it as follows:
+
+  ```shell
+    cd `go env GOPATH`/src
+    mkdir -p github.com/infobloxopen
+    cd github.com/infobloxopen
+    git clone https://github.com/infobloxopen/terraform-provider-infoblox
+    cd terraform-provider-infoblox
+    make build
   ```
-    $ cd `go env GOPATH`/src
-    $ mkdir -p github.com/infobloxopen
-    $ cd github.com/infobloxopen
-    $ git clone https://github.com/infobloxopen/terraform-provider-infoblox
-    $ cd terraform-provider-infoblox
-    $ make build
-  ```  
 
 To install the resulting binary as a plugin, follow the instructions on page:
+
   ```
     https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers
   ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://www.infoblox.com">
     <img src="https://avatars.githubusercontent.com/u/8064882?s=400&u=3b245589302c409aff2ce2ba26d95e6df6cfe342&v=4" alt="Infoblox logo" title="Infoblox" align="right" height="50" />
-</a> 
- 
+</a>
+
 # Infoblox NIOS Terraform Provider
 
 This is a provider plug-in for Terraform to manage Infoblox NIOS (Network Identity Operating System) resources using Terraform infrastructure as code solutions.
@@ -13,7 +13,7 @@ The latest version of Infoblox provider is [v2.7.0](https://github.com/infobloxo
 
 The provider plug-in has NIOS DDI resources represented as Terraform resources and data sources. The consolidated list of supported resources and data sources is as follows:
 
-### Resources:
+### Resources
 
 * Network view (`infoblox_network_view`)
 * Network container (`infoblox_ipv4_network_container`, `infoblox_ipv6_network_container`)
@@ -28,16 +28,15 @@ The provider plug-in has NIOS DDI resources represented as Terraform resources a
 * SRV-record (`infoblox_srv_record`)
 * Zone Auth (`infoblox_zone_auth`)
 * Host record as a backend for the following operations:
-    * Allocation and deallocation of an IP address from a Network (`infoblox_ip_allocation`)
-    * Association and disassociation of an IP address from a VM (`infoblox_ip_association`)
+  * Allocation and deallocation of an IP address from a Network (`infoblox_ip_allocation`)
+  * Association and disassociation of an IP address from a VM (`infoblox_ip_association`)
 * Zone Forward (`infoblox_zone_forward`)
 
 All of the above resources are supported with `comment` and `ext_attrs` fields.
 DNS records and the `infoblox_ip_allocation` resources are supported with `ttl` field.
 <br> A resource can manage its drift state by using the extensible attribute `Terraform Internal ID` when its Reference ID is changed by any manual intervention.
 
-
-### Data Sources:
+### Data Sources
 
 * Network View (`infoblox_network_view`)
 * IPv4 Network (`infoblox_ipv4_network`)
@@ -61,8 +60,8 @@ Data source of DNS records are supported with `ttl` and `zone` fields.
 
 ## Quick Start
 
-- [Getting the provider plugin](GETTING.md)
-- [Developing on the provider plugin](DEVELOP.md)
+* [Getting the provider plugin](GETTING.md)
+* [Developing on the provider plugin](DEVELOP.md)
 
 ## Documentation
 
@@ -82,17 +81,19 @@ complete the following prerequisites:
 * Configure the access permissions for Terraform to interact with NIOS Grid objects.
 * If you plan to develop a plug-in that includes features that are not in the published version,
   then install the [infoblox-go-client](https://github.com/infobloxopen/infoblox-go-client) and Go programming language.
-* To use the Infoblox IPAM Plug-In for Terraform, you must either define the following extensible attributes in NIOS or 
+* To use the Infoblox IPAM Plug-In for Terraform, you must either define the following extensible attributes in NIOS or
   install the Cloud Network Automation license in the NIOS Grid, which adds the extensible attributes by default:
-  * `Tenant ID`: String Type 
-  * `CMP Type`: String Type 
+  * `Tenant ID`: String Type
+  * `CMP Type`: String Type
   * `Cloud API Owned`: List Type (Values: True, False)
 * To use the Infoblox IPAM Plug-In for Terraform, you must either define the extensible attribute `Terraform Internal ID`
-  in NIOS or use `super user` to execute the below cmd. It will create the read only extensible attribute `Terraform Internal ID`. 
+  in NIOS or use `super user` to execute the below cmd. It will create the read only extensible attribute `Terraform Internal ID`.
   for more details refer to the [Infoblox NIOS Documentation](https://docs.infoblox.com/space/NIOS/35400616/NIOS).
+
   ```shell
   curl -k -u <SUPERUSER>:<PASSWORD> -H "Content-Type: application/json" -X POST https://<NIOS_GRID_IP>/wapi/<WAPI_VERSION>/extensibleattributedef -d '{"name": "Terraform Internal ID", "flags": "CR", "type": "STRING", "comment": "Internal ID for Terraform Resource"}'
   ```
+
 ## Limitations
 
 The limitations of Infoblox IPAM Plug-In for Terraform are as follows:
@@ -114,16 +115,16 @@ The limitations of Infoblox IPAM Plug-In for Terraform are as follows:
 * Use of capital letters in the domain name of a Terraform resource may lead to unexpected results. For example,
   when you use a Terraform data source to search for a DNS record that has capital letters in its name, no results
   are returned if you specify the name in the same text case. You must specify the name in lower case.
-* In plug-in versions prior to `v2.5.0`, the fetch functionality in data sources returns output for only one matching 
+* In plug-in versions prior to `v2.5.0`, the fetch functionality in data sources returns output for only one matching
   object even if it finds multiple objects matching the search criteria.
-* When using the Terraform `import` block for a resource, a new Terraform internal ID is assigned to the resource when 
-  the `terraform plan` command is run for the first time. If a subsequent `terraform apply` is aborted, the record will 
+* When using the Terraform `import` block for a resource, a new Terraform internal ID is assigned to the resource when
+  the `terraform plan` command is run for the first time. If a subsequent `terraform apply` is aborted, the record will
   still retain the `Terraform Internal ID` though the resource is not managed by Terraform.
 
 ## Best Practices
 
-* Infoblox recommends that you manage all resources supported by IPAM Plug-In for Terraform from Terraform only. 
+* Infoblox recommends that you manage all resources supported by IPAM Plug-In for Terraform from Terraform only.
   Modifying a resource outside of Terraform may result in unexpected behavior.
 * If you need to manage a large number of resources, Infoblox recommends that you manage them across multiple workspaces
-  instead of using a single state file to manage all resources. For more information, see [Managing Workspaces](https://developer.hashicorp.com/terraform/cli/workspaces) 
+  instead of using a single state file to manage all resources. For more information, see [Managing Workspaces](https://developer.hashicorp.com/terraform/cli/workspaces)
   and [Structuring Terraform Configuration](https://www.hashicorp.com/blog/structuring-hashicorp-terraform-configuration-for-production).

--- a/docs/data-sources/infoblox_a_record.md
+++ b/docs/data-sources/infoblox_a_record.md
@@ -31,7 +31,8 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
+### Example for using the filters
+
  ```hcl
  data "infoblox_a_record" "a_rec_filter" {
     filters = {
@@ -53,11 +54,11 @@ You can reference this resource and retrieve information about it.
 
 ```hcl
 resource "infoblox_a_record" "vip_host" {
-  fqdn = "very-interesting-host.example.com"
-  ip_addr = "10.3.1.65"
-  comment = "special host"
+  fqdn     = "very-interesting-host.example.com"
+  ip_addr  = "10.3.1.65"
+  comment  = "special host"
   dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  ttl      = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -66,11 +67,11 @@ resource "infoblox_a_record" "vip_host" {
 
 data "infoblox_a_record" "a_rec_temp" {
   filters = {
-    name = "very-interesting-host.example.com"
+    name     = "very-interesting-host.example.com"
     ipv4addr = "10.3.1.65" //alias is ip_addr
-    view = "nondefault_dnsview2"
+    view     = "nondefault_dnsview2"
   }
-  
+
   // This is just to ensure that the record has been be created
   // using 'infoblox_a_record' resource block before the data source will be queried.
   depends_on = [infoblox_a_record.vip_host]
@@ -88,7 +89,7 @@ output "a_rec_name" {
 // accessing A-Record through EA's
 data "infoblox_a_record" "a_rec_ea" {
   filters = {
-    "*Site" = "some test site"
+    "*Site"     = "some test site"
     "*Location" = "65.8665701230204, -37.00791763398113"
   }
 }
@@ -97,4 +98,3 @@ output "a_rec_out" {
   value = data.infoblox_a_record.a_rec_ea
 }
 ```
-

--- a/docs/data-sources/infoblox_aaaa_record.md
+++ b/docs/data-sources/infoblox_aaaa_record.md
@@ -31,16 +31,17 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_aaaa_record" "aaaa_rec_filter" {
-    filters = {
-        name = "debug.test.com"
-        ipv6addr = "2002::100"
-        view = "nondefault_dnsview" // associated DNS view
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_aaaa_record" "aaaa_rec_filter" {
+  filters = {
+    name     = "debug.test.com"
+    ipv6addr = "2002::100"
+    view     = "nondefault_dnsview" // associated DNS view
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -54,10 +55,10 @@ You can reference this resource and retrieve information about it.
 
 ```hcl
 resource "infoblox_aaaa_record" "vip_host" {
-  fqdn = "very-interesting-host.example.com"
+  fqdn      = "very-interesting-host.example.com"
   ipv6_addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
-  comment = "some comment"
-  ttl = 120 // 120s
+  comment   = "some comment"
+  ttl       = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -65,8 +66,8 @@ resource "infoblox_aaaa_record" "vip_host" {
 
 data "infoblox_aaaa_record" "qa_rec_temp" {
   filters = {
-    name ="very-interesting-host.example.com"
-    ipv6addr ="2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+    name     = "very-interesting-host.example.com"
+    ipv6addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
   }
 
   // This is just to ensure that the record has been be created
@@ -86,7 +87,7 @@ output "qa_rec_addr" {
 // accessing AAAA-Record through EA's
 data "infoblox_aaaa_record" "qa_rec_ea" {
   filters = {
-    "*Site" = "sample test site"
+    "*Site"     = "sample test site"
     "*Location" = "65.8665701230204, -37.00791763398113"
   }
 }

--- a/docs/data-sources/infoblox_cname_record.md
+++ b/docs/data-sources/infoblox_cname_record.md
@@ -31,15 +31,16 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_cname_record" "cname_rec_filter" {
-    filters = {
-        name = "testing.demo1.com"
-        canonical = "delivery.random.street.in"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_cname_record" "cname_rec_filter" {
+  filters = {
+    name      = "testing.demo1.com"
+    canonical = "delivery.random.street.in"
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -53,22 +54,22 @@ You can reference this resource and retrieve information about it.
 
 ```hcl
 resource "infoblox_cname_record" "foo" {
-  dns_view = "default.nondefault_netview"
+  dns_view  = "default.nondefault_netview"
   canonical = "strange-place.somewhere.in.the.net"
-  alias = "foo.test.com"
-  comment = "we need to keep an eye on this strange host"
-  ttl = 0 // disable caching
+  alias     = "foo.test.com"
+  comment   = "we need to keep an eye on this strange host"
+  ttl       = 0 // disable caching
   ext_attrs = jsonencode({
-    Site = "unknown"
+    Site     = "unknown"
     Location = "TBD"
   })
 }
 
-data "infoblox_cname_record" "cname_rec"{
+data "infoblox_cname_record" "cname_rec" {
   filters = {
-    name = "foo.test.com"
+    name      = "foo.test.com"
     canonical = "strange-place.somewhere.in.the.net"
-    view = "default.nondefault_netview"
+    view      = "default.nondefault_netview"
   }
 
   // This is just to ensure that the record has been be created

--- a/docs/data-sources/infoblox_dns_view.md
+++ b/docs/data-sources/infoblox_dns_view.md
@@ -23,15 +23,16 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_dns_view" "view_filter" {
-    filters = {
-        name = "custom_dnsview"
-        network_view = "default"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_dns_view" "view_filter" {
+  filters = {
+      name = "custom_dnsview"
+      network_view = "default"
+  }
+}
+```
 
 !> If `null` or empty filters are passed, then all the views or objects associated with datasource like here `infoblox_dns_view` will be fetched in results.
 
@@ -39,9 +40,9 @@ From the below list of supported arguments for filters,  use only the searchable
 
 ```hcl
 resource "infoblox_dns_view" "view1" {
-  name = "customview"
+  name         = "customview"
   network_view = "nondefault_netview"
-  comment = "sample custom dns view"
+  comment      = "sample custom dns view"
   ext_attrs = jsonencode({
     "Location" = "NewYork"
   })
@@ -49,10 +50,10 @@ resource "infoblox_dns_view" "view1" {
 
 data "infoblox_dns_view" "dsview" {
   filters = {
-    name = "customview"
+    name         = "customview"
     network_view = "nondefault_netview"
   }
-  
+
   // This is just to ensure that the record has been be created
   // using 'infoblox_dns_view' resource block before the data source will be queried.
   depends_on = [infoblox_dns_view.view1]

--- a/docs/data-sources/infoblox_host_record.md
+++ b/docs/data-sources/infoblox_host_record.md
@@ -32,7 +32,8 @@ The following table describes the parameters you can define in an `infoblox_host
 
 !> Aliases are the parameter names used in the prior releases of Infoblox IPAM Plug-In for Terraform. Do not use the alias names for parameters in the data source blocks. Using them can result in error scenarios.
 
-### Example for using the filters:
+### Example for using the filters
+
 ```hcl
 data "infoblox_host_record" "host_rec_filter" {
   filters = {
@@ -56,22 +57,22 @@ resource "infoblox_zone_auth" "zone1" {
 }
 
 resource "infoblox_ip_allocation" "allocation1" {
-  dns_view = "default"
+  dns_view   = "default"
   enable_dns = true
-  fqdn = "host1.example.org"
-  ipv4_addr = "10.10.0.7"
-  ipv6_addr = "1::1"
-  ext_attrs = jsonencode({"Location" = "USA"})
-  
+  fqdn       = "host1.example.org"
+  ipv4_addr  = "10.10.0.7"
+  ipv6_addr  = "1::1"
+  ext_attrs  = jsonencode({ "Location" = "USA" })
+
   depends_on = [infoblox_zone_auth.zone1]
 }
 
 resource "infoblox_ip_association" "association1" {
   internal_id = infoblox_ip_allocation.allocation1.id
-  mac_addr = "12:00:43:fe:9a:8c"
-  duid = "12:00:43:fe:9a:81"
+  mac_addr    = "12:00:43:fe:9a:8c"
+  duid        = "12:00:43:fe:9a:81"
   enable_dhcp = false
-  depends_on = [infoblox_ip_allocation.allocation1]
+  depends_on  = [infoblox_ip_allocation.allocation1]
 }
 
 data "infoblox_host_record" "host_rec_temp" {
@@ -99,4 +100,3 @@ output "host_ea_out" {
   value = data.infoblox_host_record.host_rec_ea
 }
 ```
-

--- a/docs/data-sources/infoblox_ipv4_network.md
+++ b/docs/data-sources/infoblox_ipv4_network.md
@@ -7,7 +7,6 @@ The data source for the network object allows you to get the following parameter
 * `comment`: a description of the network. This is a regular comment. Example: `Untrusted network`.
 * `ext_attrs`: The set of extensible attributes, if any. The content is formatted as string of JSON map. Example: `"{\"Owner\":\"State Library\",\"Administrator\":\"unknown\"}"`.
 
-
 For usage of filters, add the fields as keys and appropriate values to be passed to the keys like `name`, `view` corresponding to object.
 From the below list of supported arguments for filters,  use only the searchable fields for retriving the matching records.
 
@@ -24,15 +23,16 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_ipv4_network" "network_filter" {
-    filters = {
-        network = "10.11.0.0/16"
-        network_view = "nondefault_netview"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_ipv4_network" "network_filter" {
+  filters = {
+    network      = "10.11.0.0/16"
+    network_view = "nondefault_netview"
+  }
+}
+```
 
 !> From the above example, if the 'network_view' value is not specified, if same network exists in one or more different network views, those
 all networks will be fetched in results.
@@ -43,11 +43,11 @@ all networks will be fetched in results.
 
 ```hcl
 resource "infoblox_ipv4_network" "net2" {
-  cidr = "192.168.128.0/20"
+  cidr         = "192.168.128.0/20"
   network_view = "nondefault_netview"
-  reserve_ip = 5
-  gateway = "192.168.128.254"
-  comment = "small network for testing"
+  reserve_ip   = 5
+  gateway      = "192.168.128.254"
+  comment      = "small network for testing"
   ext_attrs = jsonencode({
     "Site" = "bla-bla-bla... testing..."
   })
@@ -55,7 +55,7 @@ resource "infoblox_ipv4_network" "net2" {
 
 data "infoblox_ipv4_network" "nearby_network" {
   filters = {
-    network = "192.168.128.0/20"
+    network      = "192.168.128.0/20"
     network_view = "nondefault_netview"
   }
   // This is just to ensure that the network has been be created

--- a/docs/data-sources/infoblox_ipv4_network_container.md
+++ b/docs/data-sources/infoblox_ipv4_network_container.md
@@ -2,6 +2,7 @@
 
 Use the data source to retrieve the following information for an IPv4 network container resource from the corresponding
 object in NIOS:
+
 * `network_view`: the network view which the network container exists in. Example: `nondefault_netview`
 * `cidr`: the IPv4 network block of the network container. Example: `19.17.0.0/16`
 * `comment`: a description of the network container. This is a regular comment. Example: `Tenant 1 network container`.
@@ -25,15 +26,16 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_ipv4_network_container" "nc_filter" {
-    filters = {
-        network = "10.11.0.0/16"
-        network_view = "nondefault_netview"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_ipv4_network_container" "nc_filter" {
+  filters = {
+    network      = "10.11.0.0/16"
+    network_view = "nondefault_netview"
+  }
+}
+```
 
 !> From the above example, if the 'network_view' value is not specified, if same network container exists in one or more different network views, those
 all network containers will be fetched in results.
@@ -44,11 +46,11 @@ all network containers will be fetched in results.
 
 ```hcl
 resource "infoblox_ipv4_network_container" "nearby_org" {
-  cidr = "192.168.128.0/17"
+  cidr         = "192.168.128.0/17"
   network_view = "separate_tenants"
-  comment = "one of our clients"
+  comment      = "one of our clients"
   ext_attrs = jsonencode({
-    "Site" = "remote office"
+    "Site"    = "remote office"
     "Country" = "Australia"
   })
 }
@@ -56,7 +58,7 @@ resource "infoblox_ipv4_network_container" "nearby_org" {
 data "infoblox_ipv4_network_container" "nearby_nc" {
   filters = {
     network_view = "separate_tenants"
-    network = "192.168.128.0/17"
+    network      = "192.168.128.0/17"
   }
 
   // This is just to ensure that the network container has been be created

--- a/docs/data-sources/infoblox_ipv6_network.md
+++ b/docs/data-sources/infoblox_ipv6_network.md
@@ -7,7 +7,6 @@ The data source for the network object allows you to get the following parameter
 * `comment`: a description of the network. This is a regular comment. Example: `Untrusted network`.
 * `ext_attrs`: The set of extensible attributes, if any. The content is formatted as string of JSON map. Example: `"{\"Owner\":\"State Library\",\"Administrator\":\"unknown\"}"`.
 
-
 To retrieve information about IPv6 network that match the specified filters, use the `filters` argument and specify the parameters mentioned in the below table. These are the searchable parameters of the corresponding object in Infoblox NIOS WAPI. If you do not specify any parameter, the data source retrieves information about all host records in the NIOS Grid.
 
 The following table describes the parameters you can define in an `infoblox_ipv6_network` data source block:
@@ -23,16 +22,17 @@ The following table describes the parameters you can define in an `infoblox_ipv6
 
 !> Aliases are the parameter names used in the prior releases of Infoblox IPAM Plug-In for Terraform. Do not use the alias names for parameters in the data source blocks. Using them can result in error scenarios.
 
-### Example for using the filters:
- ```hcl
+### Example for using the filters
+
+```hcl
 data "infoblox_ipv6_network" "readNet1" {
   filters = {
-    network = "2002:1f93:0:4::/96"
+    network      = "2002:1f93:0:4::/96"
     network_view = "nondefault_netview"
   }
   depends_on = [infoblox_ipv6_network.ipv6net1]
 }
- ```
+```
 
 !> If `null` or empty filters are passed, then all the networks or objects associated with datasource like here `infoblox_ipv6_network`, will be fetched in results.
 
@@ -41,10 +41,10 @@ data "infoblox_ipv6_network" "readNet1" {
 ```hcl
 // This is just to ensure that the network has been be created
 resource "infoblox_ipv6_network" "ipv6net1" {
-  cidr = "2002:1f93:0:4::/96"
+  cidr         = "2002:1f93:0:4::/96"
   reserve_ipv6 = 10
-  gateway = "2002:1f93:0:4::1"
-  comment = "let's try IPv6"
+  gateway      = "2002:1f93:0:4::1"
+  comment      = "let's try IPv6"
   ext_attrs = jsonencode({
     "Site" = "Antarctica"
   })

--- a/docs/data-sources/infoblox_ipv6_network_container.md
+++ b/docs/data-sources/infoblox_ipv6_network_container.md
@@ -2,6 +2,7 @@
 
 Use the data source to retrieve the following information for an IPv6 network container resource from the corresponding
 object in NIOS:
+
 * `network_view`: the network view which the network container exists in. Example: `nondefault_netview`
 * `cidr`: the IPv6 network block of the network container. Example: `2002:1f93:0:2::/96`
 * `comment`: a description of the network container. This is a regular comment. Example: `Tenant 1 network container`.
@@ -10,6 +11,7 @@ object in NIOS:
 To retrieve information about Ipv6 network container that match the specified filters, use the `filters` argument and specify the parameters mentioned in the below table. These are the searchable parameters of the corresponding object in Infoblox NIOS WAPI. If you do not specify any parameter, the data source retrieves information about all host records in the NIOS Grid.
 
 The following table describes the parameters you can define in an `infoblox_ipv6_network_container` data source block:
+
 ### Supported Arguments for filters
 
 -----
@@ -21,14 +23,15 @@ The following table describes the parameters you can define in an `infoblox_ipv6
 
 !> Aliases are the parameter names used in the prior releases of Infoblox IPAM Plug-In for Terraform. Do not use the alias names for parameters in the data source blocks. Using them can result in error scenarios.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_ipv6_network_container" "nc_filter" {
-    filters = {
-        network = "2002:1f93:0:2::/96"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_ipv6_network_container" "nc_filter" {
+  filters = {
+    network = "2002:1f93:0:2::/96"
+  }
+}
+```
 
 !> If `null` or empty filters are passed, then all the network containers or objects associated with datasource like here `infoblox_ipv6_network_container`, will be fetched in results.
 
@@ -37,7 +40,7 @@ The following table describes the parameters you can define in an `infoblox_ipv6
 ```hcl
 // This is just to ensure that the network container has been be created
 resource "infoblox_ipv6_network_container" "nc1" {
-  cidr = "2002:1f93:0:2::/96"
+  cidr    = "2002:1f93:0:2::/96"
   comment = "new generation network segment"
   ext_attrs = jsonencode({
     "Site" = "space station"
@@ -68,5 +71,5 @@ output "nc1_output" {
 // accessing IPv6 network container through EA's
 output "nc1_comment" {
   value = data.infoblox_ipv6_network_container.nc_ea_search
-}  
+}
 ```

--- a/docs/data-sources/infoblox_mx_record.md
+++ b/docs/data-sources/infoblox_mx_record.md
@@ -31,16 +31,17 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_mx_record" "mx_filter" {
-    filters = {
-        name = "samplemx.demo.com"
-        mail_exchanger = "mx1.secure-mail-provider.net"
-        view = "nondefault_dnsview" // associated DNS view
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_mx_record" "mx_filter" {
+  filters = {
+    name           = "samplemx.demo.com"
+    mail_exchanger = "mx1.secure-mail-provider.net"
+    view           = "nondefault_dnsview" // associated DNS view
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -51,12 +52,12 @@ all records will be fetched in results.
 
 ```hcl
 resource "infoblox_mx_record" "rec2" {
-  dns_view = "nondefault_dnsview1"
-  fqdn = "rec2.example2.org"
+  dns_view       = "nondefault_dnsview1"
+  fqdn           = "rec2.example2.org"
   mail_exchanger = "sample.test.com"
-  preference = 40
-  comment = "example MX-record"
-  ttl = 120
+  preference     = 40
+  comment        = "example MX-record"
+  ttl            = 120
   ext_attrs = jsonencode({
     "Location" = "Las Vegas"
   })
@@ -64,8 +65,8 @@ resource "infoblox_mx_record" "rec2" {
 
 data "infoblox_mx_record" "ds2" {
   filters = {
-    view = "nondefault_dnsview1"
-    name = "rec2.example2.org"
+    view           = "nondefault_dnsview1"
+    name           = "rec2.example2.org"
     mail_exchanger = "sample.test.com"
   }
 
@@ -87,7 +88,7 @@ output "mx_rec_name" {
 data "infoblox_mx_record" "mx_rec_ea" {
   filters = {
     "*Location" = "California"
-    "*TestEA" = "automate"
+    "*TestEA"   = "automate"
   }
 }
 

--- a/docs/data-sources/infoblox_network_view.md
+++ b/docs/data-sources/infoblox_network_view.md
@@ -21,14 +21,15 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_network_view" "nview_filter" {
-    filters = {
-        name = "nondefault_netview"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_network_view" "nview_filter" {
+  filters = {
+    name = "nondefault_netview"
+  }
+}
+```
 
 !> If `null` or empty filters are passed, then all the objects associated with datasource like here `infoblox_network_view` will be fetched in results.
 
@@ -36,7 +37,7 @@ From the below list of supported arguments for filters,  use only the searchable
 
 ```hcl
 resource "infoblox_network_view" "inet_nv" {
-  name = "inet_visible_nv"
+  name    = "inet_visible_nv"
   comment = "Internet-facing networks"
   ext_attrs = jsonencode({
     "Location" = "the North pole"
@@ -73,4 +74,5 @@ data "infoblox_network_view" "nview_ea" {
 output "nview_ea_out" {
   value = data.infoblox_network_view.nview_ea
 }
+
 ```

--- a/docs/data-sources/infoblox_ptr_record.md
+++ b/docs/data-sources/infoblox_ptr_record.md
@@ -35,16 +35,17 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_ptr_record" "ptr_rec_filter" {
-    filters = {
-        ptrdname = "testing.example.com"
-        view = "default" // associated DNS view
-        ipv4addr = "20.11.0.19"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_ptr_record" "ptr_rec_filter" {
+  filters = {
+    ptrdname = "testing.example.com"
+    view     = "default" // associated DNS view
+    ipv4addr = "20.11.0.19"
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -59,9 +60,9 @@ You can reference this resource and retrieve information about it.
 ```hcl
 resource "infoblox_ptr_record" "host1" {
   ptrdname = "host.example.org"
-  ip_addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
-  comment = "workstation #3"
-  ttl = 300 # 5 minutes
+  ip_addr  = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+  comment  = "workstation #3"
+  ttl      = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -69,8 +70,8 @@ resource "infoblox_ptr_record" "host1" {
 
 data "infoblox_ptr_record" "host1" {
   filters = {
-    ptrdname="host.example.org"
-    ipv6addr="2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+    ptrdname = "host.example.org"
+    ipv6addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
   }
 
   // This is just to ensure that the record has been be created
@@ -84,9 +85,9 @@ output "ptr_rec_res" {
 
 data "infoblox_ptr_record" "host2" {
   filters = {
-    view="default"
-    ptrdname="host.example.org"
-    name="0.6.a.a.7.2.f.d.2.e.2.1.d.0.c.e.0.0.b.c.5.7.2.0.4.1.0.d.5.0.a.2.ip6.arpa"
+    view     = "default"
+    ptrdname = "host.example.org"
+    name     = "0.6.a.a.7.2.f.d.2.e.2.1.d.0.c.e.0.0.b.c.5.7.2.0.4.1.0.d.5.0.a.2.ip6.arpa"
   }
 }
 

--- a/docs/data-sources/infoblox_srv_record.md
+++ b/docs/data-sources/infoblox_srv_record.md
@@ -36,16 +36,17 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_srv_record" "srv_rec_filter" {
-    filters = {
-        name = "testsrv.demo.com"
-        view = "nondefault_dnsview" // associated DNS view
-        priority = 15
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_srv_record" "srv_rec_filter" {
+  filters = {
+    name     = "testsrv.demo.com"
+    view     = "nondefault_dnsview" // associated DNS view
+    priority = 15
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -56,30 +57,30 @@ all records will be fetched in results.
 
 ```hcl
 resource "infoblox_srv_record" "rec2" {
-    dns_view = "nondefault_dnsview1"
-    name = "_sip._udp.example2.org"
-    priority = 12
-    weight = 10
-    port = 5060
-    target = "sip.example2.org"
-    ttl = 3600
-    comment = "example SRV record"
-    ext_attrs = jsonencode({
-        "Location" = "65.8665701230204, -37.00791763398113"
-    })
+  dns_view = "nondefault_dnsview1"
+  name     = "_sip._udp.example2.org"
+  priority = 12
+  weight   = 10
+  port     = 5060
+  target   = "sip.example2.org"
+  ttl      = 3600
+  comment  = "example SRV record"
+  ext_attrs = jsonencode({
+    "Location" = "65.8665701230204, -37.00791763398113"
+  })
 }
 
 data "infoblox_srv_record" "ds1" {
-    filters = {
-      view = "nondefault_dnsview1"
-      name = "_sip._udp.example2.org"
-      port = 5060
-      target = "sip.example2.org"
-    }
+  filters = {
+    view   = "nondefault_dnsview1"
+    name   = "_sip._udp.example2.org"
+    port   = 5060
+    target = "sip.example2.org"
+  }
 
   // This is just to ensure that the record has been be created
   // using 'infoblox_srv_record' resource block before the data source will be queried.
-    depends_on = [infoblox_srv_record.rec2]
+  depends_on = [infoblox_srv_record.rec2]
 }
 
 output "srv_rec_res" {
@@ -94,7 +95,7 @@ output "srv_rec_name" {
 // accessing SRV-Record through EA's
 data "infoblox_srv_record" "srv_rec_ea" {
   filters = {
-    "*Owner" = "State Library"
+    "*Owner"   = "State Library"
     "*Expires" = "never"
   }
 }

--- a/docs/data-sources/infoblox_txt_record.md
+++ b/docs/data-sources/infoblox_txt_record.md
@@ -30,16 +30,17 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_txt_record" "txt_rec_filter" {
-    filters = {
-        name = "sampletxt.demo.com"
-        text = "\"some random text\""
-        view = "default" // associated DNS view
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_txt_record" "txt_rec_filter" {
+  filters = {
+    name = "sampletxt.demo.com"
+    text = "\"some random text\""
+    view = "default" // associated DNS view
+  }
+}
+```
 
 !> From the above example, if the 'view' alias 'dns_view' value is not specified, if same record exists in one or more different DNS views, those
 all records will be fetched in results.
@@ -51,17 +52,17 @@ all records will be fetched in results.
 ```hcl
 resource "infoblox_txt_record" "rec3" {
   dns_view = "nondefault_dnsview1"
-  fqdn = "example3.example2.org"
-  text = "\"data for TXT-record #3\""
-  ttl = 300
-  comment = "example TXT record #3"
+  fqdn     = "example3.example2.org"
+  text     = "\"data for TXT-record #3\""
+  ttl      = 300
+  comment  = "example TXT record #3"
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
 }
 
 data "infoblox_txt_record" "ds3" {
-  filters =  {
+  filters = {
     view = "nondefault_dnsview1"
     name = "example3.example2.org"
   }

--- a/docs/data-sources/infoblox_zone_auth.md
+++ b/docs/data-sources/infoblox_zone_auth.md
@@ -26,16 +26,18 @@ From the below list of supported arguments for filters,  use only the searchable
 
 !> Please consider using only fields as the keys in terraform datasource filters, kindly don't use alias names as keys from the above table.
 
-### Example for using the filters:
- ```hcl
- data "infoblox_zone_auth" "zone_filter" {
-    filters = {
-        fqdn = "testing.com"
-        view = "nondefault_dnsview" // associated DNS view
-        zone_format = "FORWARD"
-    }
- }
- ```
+### Example for using the filters
+
+```hcl
+data "infoblox_zone_auth" "zone_filter" {
+  filters = {
+    fqdn        = "testing.com"
+    view        = "nondefault_dnsview" // associated DNS view
+    zone_format = "FORWARD"
+  }
+}
+```
+
 !> From the above example, if the 'view' value is not specified, if same zone name exists in one or more different DNS views, those
 all zones will be fetched in results.
 
@@ -45,11 +47,11 @@ all zones will be fetched in results.
 
 ```hcl
 resource "infoblox_zone_auth" "zone1" {
-  fqdn = "test3.com"
-  view = "default"
+  fqdn        = "test3.com"
+  view        = "default"
   zone_format = "FORWARD"
-  ns_group = "testGroup"
-  comment = "Zone Auth created newly"
+  ns_group    = "testGroup"
+  comment     = "Zone Auth created newly"
   ext_attrs = jsonencode({
     Location = "AcceptanceTerraform"
   })
@@ -57,8 +59,8 @@ resource "infoblox_zone_auth" "zone1" {
 
 data "infoblox_zone_auth" "dzone1" {
   filters = {
-    view = "default"
-    fqdn = "test3.com"
+    view        = "default"
+    fqdn        = "test3.com"
     zone_format = "FORWARD"
   }
 

--- a/docs/data-sources/infoblox_zone_forward.md
+++ b/docs/data-sources/infoblox_zone_forward.md
@@ -13,23 +13,26 @@ Use the `infoblox_zone_forward` data source to retrieve the following informatio
 * `disable`: Specifies whether the zone is disabled. Default value: `false`.
 * `forwarders_only`: Specifies whether the appliance sends queries to forwarders only, and not to other internal or Internet root servers. Default value: `false`.
 * `forward_to`: Determines the information for the remote name servers to which you want the Infoblox appliance to forward queries for a specified domain name. Example:
+
 ```terraform
 forward_to {
-    name = "te32.dz.ex.com"
-    address = "10.0.0.1"
-  }
+  name    = "te32.dz.ex.com"
+  address = "10.0.0.1"
+}
 ```
+
 * `forwarding_servers`: optional, determines the information for the Grid members to which you want the Infoblox appliance to forward queries for a specified domain name. Example:
+
 ```terraform
 forwarding_servers {
-    name = "infoblox.172_28_83_0"
-    forwarders_only = true
-    use_override_forwarders = true
-    forward_to {
-      name = "kk.fwd.com"
-      address = "10.2.1.31"
-    }
+  name                    = "infoblox.172_28_83_0"
+  forwarders_only         = true
+  use_override_forwarders = true
+  forward_to {
+    name    = "kk.fwd.com"
+    address = "10.2.1.31"
   }
+}
 ```
 
 For usage of filters, add the fields as keys and appropriate values to be passed to the keys like `fqdn`, `view` corresponding to object.
@@ -45,20 +48,21 @@ From the below list of supported arguments for filters,  use only the searchable
 | zone_format | zone_format | string | yes        |
 | comment     | comment     | string | yes        |
 
-
 !> Any combination of searchable fields in the supported arguments list for fields is allowed.
 
 !> "Aliases are the parameter names used in the prior releases of Infoblox IPAM Plug-In for Terraform. Do not use the alias names for parameters in the data source blocks. Using them can result in error scenarios."
 
-### Example for using the filters:
- ```hcl
+### Example for using the filters
+
+```hcl
 data "infoblox_zone_forward" "data_zone_forward" {
   filters = {
     fqdn = "zone_forward.ex.org"
     view = "default"
   }
 }
- ```
+```
+
 !> From the above example, if the 'view' value is not specified, if same zone name exists in one or more different DNS views, those
 all zones will be fetched in results.
 
@@ -70,11 +74,11 @@ all zones will be fetched in results.
 resource "infoblox_zone_forward" "forwardzone_forwardTo" {
   fqdn = "zone_forward.ex.org"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
   ext_attrs = jsonencode({
@@ -85,8 +89,8 @@ resource "infoblox_zone_forward" "forwardzone_forwardTo" {
 // accessing Zone Forward by specifying fqdn, view and extra attribute Site
 data "infoblox_zone_forward" "data_zone_forward" {
   filters = {
-    fqdn = "zone_forward.ex.org"
-    view = "default"
+    fqdn    = "zone_forward.ex.org"
+    view    = "default"
     "*Site" = "Antarctica"
   }
   // This is just to ensure that the record has been be created
@@ -100,18 +104,18 @@ output "zone_forward_data3" {
 
 
 resource "infoblox_zone_forward" "forwardzone_IPV4_nsGroup_externalNsGroup" {
-  fqdn = "195.1.0.0/24"
-  comment = "Forward zone IPV4"
+  fqdn              = "195.1.0.0/24"
+  comment           = "Forward zone IPV4"
   external_ns_group = "stub server"
-  zone_format = "IPV4"
-  ns_group = "test"
+  zone_format       = "IPV4"
+  ns_group          = "test"
 }
 
 // accessing Zone Forward by specifying fqdn, view and comment
 data "infoblox_zone_forward" "datazone_foward_fqdn_view_comment" {
   filters = {
-    fqdn = "195.1.0.0/24"
-    view = "default"
+    fqdn    = "195.1.0.0/24"
+    view    = "default"
     comment = "Forward zone IPV4"
   }
   // This is just to ensure that the record has been be created

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Whether you intend to use the published plug-in or the customized version that y
 
 - Install and set up a physical or virtual Infoblox NIOS appliance and has necessary licenses installed. Configure the access permissions for Terraform to interact with NIOS Grid objects.
 - To use the Infoblox IPAM Plug-In for Terraform, you must either define the following extensible attributes or install the Cloud Network Automation license in the NIOS Grid, which adds the extensible attributes by default:
+
 ```json
 {
     "Tenant ID": "String Type",
@@ -13,15 +14,18 @@ Whether you intend to use the published plug-in or the customized version that y
     "Cloud API Owned": "List Type (Values True, False)"
 }
 ```
+
 You may add other extensible attributes that you want to use.
+
 - Create an extensible attribute by name Terraform Internal ID of type string in Infoblox NIOS as given in below curl command.
+
 ```bash
 curl -k -u <user>:<password> -H "Content-Type: application/json" -X POST https://<Grid_IP>/wapi/v2.12/extensibleattributedef -d '{"name": "Terraform Internal ID", "flags": "CR", "type": "STRING", "comment": "Internal ID for Terraform Resource"}'
 ```
 
 > **Note:**
 >
->Either the Terraform Internal ID extensible attribute definition must be present in NIOS or IPAM Plug-In for Terraform 
+>Either the Terraform Internal ID extensible attribute definition must be present in NIOS or IPAM Plug-In for Terraform
 must be configured with superuser access for it to automatically create the extensible attribute. If not, the connection
  to Terraform will fail.
 >
@@ -30,7 +34,6 @@ the creation of the extensible attribute is not managed by IPAM Plug-In for Terr
 >
 >You must not modify the Terraform Internal ID for a resource under any circumstances. If it is modified, the resource
  will no longer be managed by Terraform.
-
 
 ## Configuring Infoblox Terraform IPAM Plug-In
 
@@ -41,6 +44,7 @@ As a prerequisite, configure provider authentication to set up the required acce
 To configure IPAM Plug-In for Terraform for use, complete the following steps:
 
 In the .tf file, specify the plug-in version in the required_providers block as follows in .tf file:
+
 ```hcl
 terraform {
     required_providers {
@@ -54,9 +58,8 @@ terraform {
 
 Configure the credentials required to access the NIOS Grid as environment variables or provider block in .tf file:
 
-
 ```bash
- # Using environment variable 
+ # Using environment variable
  $ export INFOBLOX_SERVER=<nios_ip-addr or nios_hostname>
  $ export INFOBLOX_USERNAME=<nios_username>
  $ export INFOBLOX_PASSWORD=<nios_password>
@@ -73,7 +76,8 @@ provider "infoblox" {
 
 Add other environment variables that you intend to use.
 You can set the following environment variables instead of defining them as attributes inside the provider block in the .tf file. Each of these environment variables has a corresponding attribute in the provider block.
-```
+
+```shell
 PORT
 SSLMODE
 CONNECT_TIMEOUT
@@ -87,20 +91,20 @@ Run the terraform init command in the directory where the .tf file is located to
 
 There are resources for the following objects, supported by the plugin:
 
-* Network view (`infoblox_network_view`)
-* Network container (`infoblox_ipv4_network_container`, `infoblox_ipv6_network_container`)
-* Network (`infoblox_ipv4_network`, `infoblox_ipv6_network`)
-* A-record (`infoblox_a_record`)
-* AAAA-record (`infoblox_aaaa_record`)
-* DNS View (`infoblox_dns_view`)
-* PTR-record (`infoblox_ptr_record`)
-* CNAME-record (`infoblox_cname_record`)
-* MX-record (`infoblox_mx_record`)
-* TXT-record (`infoblox_txt_record`)
-* SRV-record (`infoblox_srv_record`)
-* Zone Auth (`infoblox_zone_auth`)
-* Zone Forward (`infoblox_zone_forward`)
-* Host record (`infoblox_ip_allocation` / `infoblox_ip_association`)
+- Network view (`infoblox_network_view`)
+- Network container (`infoblox_ipv4_network_container`, `infoblox_ipv6_network_container`)
+- Network (`infoblox_ipv4_network`, `infoblox_ipv6_network`)
+- A-record (`infoblox_a_record`)
+- AAAA-record (`infoblox_aaaa_record`)
+- DNS View (`infoblox_dns_view`)
+- PTR-record (`infoblox_ptr_record`)
+- CNAME-record (`infoblox_cname_record`)
+- MX-record (`infoblox_mx_record`)
+- TXT-record (`infoblox_txt_record`)
+- SRV-record (`infoblox_srv_record`)
+- Zone Auth (`infoblox_zone_auth`)
+- Zone Forward (`infoblox_zone_forward`)
+- Host record (`infoblox_ip_allocation` / `infoblox_ip_association`)
 
 Network and network container resources have two versions: IPv4 and IPv6. In
 addition, there are two operations which are implemented as resources:
@@ -136,39 +140,40 @@ But the plugin does use the name `default` for the view, despite which view is m
 
 There are data sources for the following objects:
 
-* Network View (`infoblox_network_view`)
-* IPv4 Network (`infoblox_ipv4_network`)
-* IPv6 Network (`infoblox_ipv6_network`)
-* IPv4 Network Container (`infoblox_ipv4_network_container`)
-* IPv6 Network Container (`infoblox_ipv6_network_container`)
-* A-record (`infoblox_a_record`)
-* AAAA-record (`infoblox_aaaa_record`)
-* CNAME-record (`infoblox_cname_record`)
-* DNS View (`infoblox_dns_view`)
-* PTR-record (`infoblox_ptr_record`)
-* MX-record (`infoblox_mx_record`)
-* TXT-record (`infoblox_txt_record`)
-* SRV-record (`infoblox_srv_record`)
-* Zone Auth (`infoblox_zone_auth`)
-* Zone Forward (`infoblox_zone_forward`)
-* Host Record (`infoblox_host_record`)
+- Network View (`infoblox_network_view`)
+- IPv4 Network (`infoblox_ipv4_network`)
+- IPv6 Network (`infoblox_ipv6_network`)
+- IPv4 Network Container (`infoblox_ipv4_network_container`)
+- IPv6 Network Container (`infoblox_ipv6_network_container`)
+- A-record (`infoblox_a_record`)
+- AAAA-record (`infoblox_aaaa_record`)
+- CNAME-record (`infoblox_cname_record`)
+- DNS View (`infoblox_dns_view`)
+- PTR-record (`infoblox_ptr_record`)
+- MX-record (`infoblox_mx_record`)
+- TXT-record (`infoblox_txt_record`)
+- SRV-record (`infoblox_srv_record`)
+- Zone Auth (`infoblox_zone_auth`)
+- Zone Forward (`infoblox_zone_forward`)
+- Host Record (`infoblox_host_record`)
 
 !> From version 2.5.0, new feature filters are introduced. Now the data sources support to populate more than one
 matching NIOS objects.
 
-* `filters`: the schema, with passing combination of searchable fields are supported by NIOS server, which
+- `filters`: the schema, with passing combination of searchable fields are supported by NIOS server, which
 returns one or more matching objects from the NIOS server.
 
 For usage of filters, add the fields as keys and appropriate values to be passed to the keys like `name`, `view` corresponding to object.
 
-### Example for using filters:
+### Example for using filters
+
 ```hcl
 resource "infoblox_a_record" "vip_host" {
-  fqdn = "very-interesting-host.example.com"
-  ip_addr = "10.3.1.65"
-  comment = "special host"
+  fqdn     = "very-interesting-host.example.com"
+  ip_addr  = "10.3.1.65"
+  comment  = "special host"
   dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  ttl      = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -177,9 +182,9 @@ resource "infoblox_a_record" "vip_host" {
 
 data "infoblox_a_record" "a_rec_temp" {
   filters = {
-    name = "very-interesting-host.example.com"
+    name     = "very-interesting-host.example.com"
     ipv4addr = "10.3.1.65" //alias is ip_addr
-    view = "nondefault_dnsview2"
+    view     = "nondefault_dnsview2"
   }
 
   // This is just to ensure that the record has been be created
@@ -201,29 +206,32 @@ The list of matching objects as JSON format returned in output under results, wi
 
 Filters will support `EA Search` i.e, fetches matching objects or records associated with the EAs' corresponding to provided data source, if any.
 
-### Example for using filters for EA Search:
- ```hcl
+### Example for using filters for EA Search
+
+```hcl
  data "infoblox_a_record" "a_rec1" {
-    filters = {
-        "*TestEA" = "Acceptance Test"
-    }
- }
- ```
+  filters = {
+    "*TestEA" = "Acceptance Test"
+  }
+}
+```
+
 Filters will also support Multi Value EA Search, where if the EA has more than one value, to be passed as comma seperated
 value as a string. In here EAs' can have multiple or multi values of types like 'string', 'integer', etc.
 
-### Example for using Multi Value EA Search:
+### Example for using Multi Value EA Search
+
 ```hcl
 data "infoblox_a_record" "a_rec2" {
-    filters = {
-        "*tf_multi_val" = "test,test2,demo"
-    }
- }
+  filters = {
+    "*tf_multi_val" = "test,test2,demo"
+  }
+}
 
 // for negative condition, if there are common EA values associated with different objects, to fetch unique record or object
 data "infoblox_a_record" "a_rec3" {
   filters = {
-    "*tf_multi_val" = "test"
+    "*tf_multi_val"  = "test"
     "*tf_multi_val!" = "dummy"
   }
 }
@@ -237,17 +245,19 @@ As of now, there is a limitation: you have to write full resource's definition y
 In general, the process of importing an existing resource looks like this:
 
 - write a new Terraform file (ex. a-record-imported.tf) with the content:
-  ```
+
+  ```hcl
   resource "infoblox_a_record" "a_rec_1_imported" {
-    fqdn = "rec-a-1.imported.test.com"
+    fqdn    = "rec-a-1.imported.test.com"
     ip_addr = "192.168.1.2"
-    ttl = 10
+    ttl     = 10
     comment = "A-record to be imported"
     ext_attrs = jsonencode({
       "Location" = "New office"
     })
   }
   ```
+
 - get a reference for the resource you want to import (ex. by using `curl` tool)
 - issue a command of the form `terraform import RESOURCE_TYPE.RESOURCE_NAME RESOURCE_REFERENCE`.
   Example: `terraform import infoblox_a_record.a_rec_1_imported record:a/ZG5zLmJpbmRfYSQuX2RlZmF1bHQub3JnLmV4YW1wbGUsc3RhdGljMSwxLjIuMy40:rec-a-1.imported.test.com/default`
@@ -261,18 +271,18 @@ which will actually set the value of the property to the one which you defined (
 To import a host record (represented by the `infoblox_ip_allocation` and
 `infoblox_ip_association` resources in Terraform), add the `Terraform Internal ID` extensible attribute
 with a randomly generated value in the form of a UUID to the record.
+
 - For steps to add the extensible attribute, refer to the [Infoblox NIOS Documentation](https://docs.infoblox.com).
 - You may use the command-line tool `uuid` for Linux-based systems to generate a UUID.
 
 > The `Terraform Internal ID` extensible attribute is not shown in to terraform.tfstate file. Use it to create
    or import the `infoblox_ip_allocation` and `infoblox_ip_association` resources.
    You must not add it in a resource block with other extensible attributes.
-
-> You must not delete (ex. with 'terraform destroy' command) an `infoblox_ip_association` resource right after importing, but you may do this after 'terraform apply'.
+>
+> _You must not delete_ (ex. with 'terraform destroy' command) an `infoblox_ip_association` resource right after importing, but you may do this after 'terraform apply'.
    The reason: after 'terraform import' the dependency between `infoblox_ip_association` and respective `infoblox_ip_allocation` is not established by Terraform.
 
-
-### Utilizing the Import Block to Import Resources:
+### Utilizing the Import Block to Import Resources
 
 As a prerequisite, for the object that you need to import, obtain the reference ID assigned to the object in NIOS.
 
@@ -284,32 +294,35 @@ import {
   id = "reference_id"
 }
 ```
+
 #### Example for importing A-records from a zone
+
 ```hcl
-//import all A-records from the zone /example1.org 
+//import all A-records from the zone /example1.org
 data "infoblox_a_record" "data_arec" {
-    filters = {
-      zone = "example1.org "
-      view = "default"
+  filters = {
+    zone = "example1.org "
+    view = "default"
   }
 }
 
 import {
-    for_each = data.infoblox_a_record.data_arec.results
-    id       = each.value.id
-    to       = infoblox_a_record.imported_records["${each.value.fqdn}"]
+  for_each = data.infoblox_a_record.data_arec.results
+  id       = each.value.id
+  to       = infoblox_a_record.imported_records["${each.value.fqdn}"]
 }
 
 resource "infoblox_a_record" "imported_records" {
-    for_each = { for record in data.infoblox_a_record.data_arec.results : record.fqdn => record }
-    fqdn      = each.value.fqdn
-    ip_addr   = each.value.ip_addr
-    dns_view  = each.value.dns_view
-    ttl       = each.value.ttl
-    comment   = each.value.comment
-    ext_attrs = each.value.ext_attrs
+  for_each  = { for record in data.infoblox_a_record.data_arec.results : record.fqdn => record }
+  fqdn      = each.value.fqdn
+  ip_addr   = each.value.ip_addr
+  dns_view  = each.value.dns_view
+  ttl       = each.value.ttl
+  comment   = each.value.comment
+  ext_attrs = each.value.ext_attrs
 }
 ```
+
 > **Note:**
-> 
+>
 > When using the Terraform import block for a resource, a new Terraform internal ID is assigned to the resource when the terraform plan command is run for the first time. If a subsequent terraform apply is aborted, the record will still retain the Terraform Internal ID though the resource is not managed by Terraform.

--- a/docs/resources/infoblox_a_record.md
+++ b/docs/resources/infoblox_a_record.md
@@ -11,8 +11,8 @@ The following list describes the parameters you can define in the resource block
 * `comment`: optional, describes the record. Example: `static record #1`
 * `ext_attrs`: koptional, a set of NIOS extensible attributes that are attached to the record. Example: `jsonencode({})`
 * `ip_addr`: required only for static allocation, specifies the IPv4 address to associate with the A-record. Example: `91.84.20.6`.
-    * For allocating a static IP address, specify a valid IP address.
-    * For allocating a dynamic IP address, configure the `cidr` field instead of `ip_addr` . Optionally, specify a `network_view` if you do not want to allocate it in the network view `default`.
+  * For allocating a static IP address, specify a valid IP address.
+  * For allocating a dynamic IP address, configure the `cidr` field instead of `ip_addr` . Optionally, specify a `network_view` if you do not want to allocate it in the network view `default`.
 * `cidr`: required only for dynamic allocation, specifies the network from which to allocate an IP address when the `ip_addr` field is empty. The address is in CIDR format. For static allocation, use `ip_addr` instead of `cidr`. Example: `192.168.10.4/30`.
 
 !> To use upper case letters in `fqdn`, infoblox recommends that you use lower() function. Example: `lower("testEXAMPLE.zone1.com")`
@@ -22,17 +22,17 @@ The following list describes the parameters you can define in the resource block
 ```hcl
 // static A-record, minimal set of parameters
 resource "infoblox_a_record" "a_rec1" {
-  fqdn = "static1.example1.org"
+  fqdn    = "static1.example1.org"
   ip_addr = "1.3.5.4" // not necessarily from a network existing in NIOS DB
 }
 
 // all the parameters for a static A-record
 resource "infoblox_a_record" "a_rec2" {
-  fqdn = "static2.example4.org"
-  ip_addr = "1.3.5.1"
-  comment = "example static A-record a_rec2"
+  fqdn     = "static2.example4.org"
+  ip_addr  = "1.3.5.1"
+  comment  = "example static A-record a_rec2"
   dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  ttl      = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -40,12 +40,12 @@ resource "infoblox_a_record" "a_rec2" {
 
 // all the parameters for a dynamic A-record
 resource "infoblox_a_record" "a_rec3" {
-  fqdn = "dynamic1.example2.org"
-  cidr = infoblox_ipv4_network.net2.cidr // the network  must exist, you may use the example for infoblox_ipv4_network resource.
+  fqdn         = "dynamic1.example2.org"
+  cidr         = infoblox_ipv4_network.net2.cidr         // the network  must exist, you may use the example for infoblox_ipv4_network resource.
   network_view = infoblox_ipv4_network.net2.network_view // not necessarily in the same network view as the DNS view resides in.
-  comment = "example dynamic A-record a_rec3"
-  dns_view = "nondefault_dnsview1"
-  ttl = 0 // 0 = disable caching
-  ext_attrs = jsonencode({})
+  comment      = "example dynamic A-record a_rec3"
+  dns_view     = "nondefault_dnsview1"
+  ttl          = 0 // 0 = disable caching
+  ext_attrs    = jsonencode({})
 }
 ```

--- a/docs/resources/infoblox_aaaa_record.md
+++ b/docs/resources/infoblox_aaaa_record.md
@@ -22,17 +22,17 @@ The following list describes the parameters you can define in the resource block
 ```hcl
 // static AAAA-record, minimal set of parameters
 resource "infoblox_aaaa_record" "aaaa_rec1" {
-  fqdn = "static1.example1.org"
+  fqdn      = "static1.example1.org"
   ipv6_addr = "2002:1111::1401" // not necessarily from a network existing in NIOS DB
 }
 
 // all the parameters for a static AAAA-record
 resource "infoblox_aaaa_record" "aaaa_rec2" {
-  fqdn = "static2.example4.org"
+  fqdn      = "static2.example4.org"
   ipv6_addr = "2002:1111::1402"
-  comment = "example static AAAA-record aaaa_rec2"
-  dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  comment   = "example static AAAA-record aaaa_rec2"
+  dns_view  = "nondefault_dnsview2"
+  ttl       = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -40,12 +40,12 @@ resource "infoblox_aaaa_record" "aaaa_rec2" {
 
 // all the parameters for a dynamic AAAA-record
 resource "infoblox_aaaa_record" "aaaa_rec3" {
-  fqdn = "dynamic1.example2.org"
-  cidr = infoblox_ipv6_network.net2.cidr // the network  must exist, you may use the example for infoblox_ipv6_network resource.
+  fqdn         = "dynamic1.example2.org"
+  cidr         = infoblox_ipv6_network.net2.cidr         // the network  must exist, you may use the example for infoblox_ipv6_network resource.
   network_view = infoblox_ipv6_network.net2.network_view // not necessarily in the same network view as the DNS view resides in.
-  comment = "example dynamic AAAA-record aaaa_rec3"
-  dns_view = "nondefault_dnsview1"
-  ttl = 0 // 0 = disable caching
-  ext_attrs = jsonencode({})
+  comment      = "example dynamic AAAA-record aaaa_rec3"
+  dns_view     = "nondefault_dnsview1"
+  ttl          = 0 // 0 = disable caching
+  ext_attrs    = jsonencode({})
 }
 ```

--- a/docs/resources/infoblox_cname_record.md
+++ b/docs/resources/infoblox_cname_record.md
@@ -17,18 +17,18 @@ The following list describes the parameters you can define in the `infoblox_cnam
 // CNAME-record, minimal set of parameters
 resource "infoblox_cname_record" "cname_rec1" {
   canonical = "bla-bla-bla.somewhere.in.the.net"
-  alias = "hq-server.example1.org"
+  alias     = "hq-server.example1.org"
 }
 
 // CNAME-record, full set of parameters
 resource "infoblox_cname_record" "cname_rec2" {
-  dns_view = "default.nondefault_netview"
+  dns_view  = "default.nondefault_netview"
   canonical = "strange-place.somewhere.in.the.net"
-  alias = "alarm-server.example3.org"
-  comment = "we need to keep an eye on this strange host"
-  ttl = 0 // disable caching
+  alias     = "alarm-server.example3.org"
+  comment   = "we need to keep an eye on this strange host"
+  ttl       = 0 // disable caching
   ext_attrs = jsonencode({
-    Site = "unknown"
+    Site     = "unknown"
     Location = "TBD"
   })
 }

--- a/docs/resources/infoblox_dns_view.md
+++ b/docs/resources/infoblox_dns_view.md
@@ -24,9 +24,9 @@ resource "infoblox_dns_view" "view1" {
 
 //creating DNS view resource with full set of parameters
 resource "infoblox_dns_view" "view2" {
-  name = "customview"
+  name         = "customview"
   network_view = "default"
-  comment = "test dns view example"
+  comment      = "test dns view example"
   ext_attrs = jsonencode({
     "Site" = "Main test site"
   })
@@ -34,9 +34,9 @@ resource "infoblox_dns_view" "view2" {
 
 // creating DNS View under non default network view
 resource "infoblox_dns_view" "view3" {
-  name = "custom_view"
+  name         = "custom_view"
   network_view = "non_defaultview"
-  comment = "example under custom network view"
+  comment      = "example under custom network view"
   ext_attrs = jsonencode({
     "Site" = "Cal Site"
   })

--- a/docs/resources/infoblox_ip_allocation.md
+++ b/docs/resources/infoblox_ip_allocation.md
@@ -2,7 +2,7 @@
 
 The `infoblox_ip_allocation` resource allows allocation of a new IP address from a network that already exists as a NIOS object. The IP address can be allocated statically by specifying an address or dynamically as the next available IP address from the specified IPv4 and/or IPv6 network blocks. The allocation is done by creating a host record in NIOS with an IPv4 address, an IPv6 address, or both assigned to the record. The allocated IP address is marked as ‘used’ in the appropriate network block.
 
--> As a prerequisite for creation of Host records using the `infoblox_ip_allocation` and `infoblox_ip_association` resources, you must create the extensible attribute `Terraform Internal ID` of string type in Infoblox NIOS Grid Manager. For steps, refer to the [Infoblox NIOS Documentation] (https://docs.infoblox.com/space/NIOS/35400616/NIOS).
+-> As a prerequisite for creation of Host records using the `infoblox_ip_allocation` and `infoblox_ip_association` resources, you must create the extensible attribute `Terraform Internal ID` of string type in Infoblox NIOS Grid Manager. For steps, refer to the [Infoblox NIOS Documentation] (<https://docs.infoblox.com/space/NIOS/35400616/NIOS>).
 
 The following list describes the parameters you can define in the `infoblox_ip_allocation` resource block:
 
@@ -13,7 +13,7 @@ The following list describes the parameters you can define in the `infoblox_ip_a
   you must remove the zone part from the record name and
   keep only the host name.
   For example, hostname1.zone.com must be changed to `hostname1`.
-  Example: ` ip-12-34-56-78.us-west-2.compute.internal`.
+  Example: `ip-12-34-56-78.us-west-2.compute.internal`.
 * `network_view`: optional, specifies the network view from which to get the specified network block.
   If a value is not specified, the name `default` is set as the network view. Example: `dmz_netview`.
 * `dns_view`: optional, specifies the DNS view in which to create the DNS
@@ -32,14 +32,14 @@ The following list describes the parameters you can define in the `infoblox_ip_a
       For example, the FQDN with `host1` as the record name and zone as `example.org`, must be changed from `host1.example.org` to `host1`.
   * If you set the parameter from `false` to `true`, you must:
     * Specify the `dns_view` parameter because if a value is not specified, the name `default` is NOT configured.
-    *  Change the `fqdn` value to FQDN without a leading dot, that means, add a zone that exists in the specified DNS view to the
+    * Change the `fqdn` value to FQDN without a leading dot, that means, add a zone that exists in the specified DNS view to the
        name of the host record. For example, if the `fqdn` value is `host1` and the zone
        selected from the specified DNS view is `example.com`, then the `fqdn` must be changed to `host1.example.com`.
 * `ipv4_cidr`: required only for dynamic allocation, specifies the IPv4 network block (in CIDR format) from where to allocate the next available IP address.
   Use this parameter only when `ipv4_addr` is not specified. Example: `10.0.0.0/24`.
 * `ipv6_cidr`: required only for dynamic allocation, specifies the IPv6 network block (in CIDR format) from where to allocate the next available IP address.
   Use this parameter only when `ipv6_addr` is not specified. Example: `2000:1148::/32`.
-* `ipv4_addr`: required only for static allocation, specifies an IPv4 address to allocate. 
+* `ipv4_addr`: required only for static allocation, specifies an IPv4 address to allocate.
   Use this parameter only when `ipv4_cidr` is not specified. The allocated IP address will be marked as ‘Used’ in NIOS Grid Manager.
   The default value is an empty string. If you specify both `ipv4_addr` and `ipv4_cidr`, then `ipv4_addr` is ignored.
   Example: `10.0.0.10`.
@@ -52,11 +52,12 @@ The following list describes the parameters you can define in the `infoblox_ip_a
 * `comment`: optional, specifies the human-readable description of the resource. Example: `Front-end cloud node`.
 * `ext_attrs`: optional, specifies the set of NIOS extensible attributes that are attached to the NIOS resource.
   An extensible attribute must be a JSON map translated into a string value. Example:
-```
+
+```hcl
 jsonencode({
   "Tenant ID" = "tf-plugin"
-  "Location" = "Test loc."
-  "Site" = "Test site"
+  "Location"  = "Test loc."
+  "Site"      = "Test site"
 })
 ```
 
@@ -67,20 +68,20 @@ dependencies have been configured for network view and the extensible attribute,
 ```hcl
 resource "infoblox_ip_allocation" "ip_allocation" {
   network_view = infoblox_ipv6_network.ipv6_network.network_view
-  ipv4_addr = "10.0.0.32"
-  ipv6_addr = "2001:1890:1959:2710::32"
+  ipv4_addr    = "10.0.0.32"
+  ipv6_addr    = "2001:1890:1959:2710::32"
 
   #Create Host Record with DNS flags
-  dns_view="default"
-  fqdn="testipv4v6"
+  dns_view   = "default"
+  fqdn       = "testipv4v6"
   enable_dns = "false"
 
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"    = "tf-plugin"
     "Network Name" = lookup(jsondecode(infoblox_ipv4_network.ipv4_network.ext_attrs), "Network Name")
-    "VM Name" = "tf-vmware-ipv4-ipv61"
-    "Location" = "Test loc."
-    "Site" = "Test site"
+    "VM Name"      = "tf-vmware-ipv4-ipv61"
+    "Location"     = "Test loc."
+    "Site"         = "Test site"
   })
 }
 ```
@@ -90,11 +91,12 @@ When you perform a `create` or an `update` operation using this allocation resou
 * `allocated_ipv4_addr`: if you allocated a dynamic IP address, this value is the IP address allocated from the specified IPv4 CIDR.
   If you allocated a static IP address, this value is the IP address that you specified in the `ipv4_addr` field.
   You can reference this field for the IP address when using other resources. Example:
+
 ```hcl
 resource "infoblox_ip_aloocation" "allocation1" {
-  dns_view = "default"
+  dns_view  = "default"
   ipv4_cidr = infoblox_ipv4_network.cidr
-  fqdn = local.vm_name
+  fqdn      = local.vm_name
 }
 # You can add a reference for the IP address as follows: infoblox_ip_allocation.allocation1.allocated_ipv4_addr
 ```
@@ -113,17 +115,17 @@ resource.
 resource "infoblox_ip_allocation" "allocation1" {
   dns_view = "default" // this time the parameter is not optional, because...
   # enable_dns = true // ... this is 'true', by default
-  fqdn = "host1.example1.org" // this resource type is implemented as a host record on NIOS side
+  fqdn      = "host1.example1.org" // this resource type is implemented as a host record on NIOS side
   ipv4_addr = "1.2.3.4"
 }
 
 // Wide set of parameters
 resource "infoblox_ip_allocation" "allocation2" {
-  dns_view = "nondefault_dnsview1"
-  fqdn = "host2.example2.org"
+  dns_view  = "nondefault_dnsview1"
+  fqdn      = "host2.example2.org"
   ipv6_addr = "2002:1f93::1234"
-  ttl = 120
-  comment = "another host record, statically allocated"
+  ttl       = 120
+  comment   = "another host record, statically allocated"
   ext_attrs = jsonencode({
     "Tenant ID" = "tenant_3261798"
   })
@@ -131,13 +133,13 @@ resource "infoblox_ip_allocation" "allocation2" {
 
 // IPv4 and IPv6 at the same time
 resource "infoblox_ip_allocation" "allocation3" {
-  dns_view = "nondefault_dnsview2"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview" // we have to mention the exact network view which the DNS view belongs to
-  fqdn = "host3.example4.org"
-  ipv6_addr = "2002:1f93::12:40"
-  ipv4_addr = "1.2.3.40"
-  ttl = 0
-  comment = "still statically allocated, but IPv4 and IPv6 together"
+  fqdn         = "host3.example4.org"
+  ipv6_addr    = "2002:1f93::12:40"
+  ipv4_addr    = "1.2.3.40"
+  ttl          = 0
+  comment      = "still statically allocated, but IPv4 and IPv6 together"
   ext_attrs = jsonencode({
     "Tenant ID" = "tenant_3261798"
   })
@@ -148,7 +150,7 @@ resource "infoblox_ip_allocation" "allocation4" {
   # dns_view = "nondefault_dnsview2" // dns_view makes no sense when enable_dns = false and
   // you MUST remove it or comment out
   network_view = "nondefault_netview" // we have to mention the exact network view which the DNS view belongs to
-  fqdn = "host4" // just one name component, because there is no host-to-DNS-zone assignment
+  fqdn         = "host4"              // just one name component, because there is no host-to-DNS-zone assignment
 
   // either of the IP addresses must belong to an existing
   // network (not a network container) in the GIVEN network view,
@@ -162,10 +164,10 @@ resource "infoblox_ip_allocation" "allocation4" {
 
 // dynamic allocation
 resource "infoblox_ip_allocation" "allocation5" {
-  dns_view = "nondefault_dnsview2"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview"
-  fqdn = "host5.example4.org"
-  ipv6_cidr = infoblox_ipv6_network.net2.cidr
-  ipv4_cidr = infoblox_ipv4_network.net2.cidr
+  fqdn         = "host5.example4.org"
+  ipv6_cidr    = infoblox_ipv6_network.net2.cidr
+  ipv4_cidr    = infoblox_ipv4_network.net2.cidr
 }
 ```

--- a/docs/resources/infoblox_ip_association.md
+++ b/docs/resources/infoblox_ip_association.md
@@ -26,7 +26,7 @@ The following list describes the parameters you can define in the `infoblox_ip_a
 
   Example: `02:42:97:87:70:f9`.
 
-* `duid`: required only if the Host record has an IPv6 address, applies only for IPv6 addresses. 
+* `duid`: required only if the Host record has an IPv6 address, applies only for IPv6 addresses.
   It specifies the DHCPv6 Unique Identifier (DUID) of the address object.
   The default is an empty string. Example: `34:df:37:1a:d9:7f`
   (The DUID could be the same type of value as the MAC address of a network interface).
@@ -68,7 +68,7 @@ resource "infoblox_ip_association" "association3" {
   enable_dhcp = true // all systems go
 
   mac_addr = "12:43:fd:ba:9c:c9"
-  duid = "00:43:d2:0a:11:e6"
+  duid     = "00:43:d2:0a:11:e6"
 }
 
 resource "infoblox_ip_association" "association4" {

--- a/docs/resources/infoblox_ipv4_allocation.md
+++ b/docs/resources/infoblox_ipv4_allocation.md
@@ -7,6 +7,7 @@ The `infoblox_ipv4_allocation` resource allows allocation of the next available 
 The allocation is done by creating a Host record in NIOS. The Host record can be created at the DNS server side by using the `enable_dns` flag, which is enabled by default. If you disable the flag, the record is not created in the DNS server side, but is visible on the IPAM tab in NIOS Grid Manager.
 
 When you create the Host record at the DNS server side, specify the host name in the FQDN format. The name must include the zone name and the host name as shown in the following example:
+
 ```
 enable_dns=true
 fqdn=hostname1.zone.com
@@ -17,7 +18,7 @@ If you disable the `enable_dns` flag, specify only the host name as FQDN. For ex
 The following list describes the parameters you can define in the IP address allocation resource blocks:
 
 * `fqdn`: required, specifies the name (in FQDN format) of a host for which an IP address needs to be allocated. When `enable_dns` is set to `true`, specify the zone name along with the host name in format: <hostname>.<zone>.
-  When `enable_dns` is set to `false`, specify only the host name: <hostname>. In a cloud environment, a VM name could be used as a host name. Example: ` ip-12-34-56-78.us-west-2.compute.internal`.
+  When `enable_dns` is set to `false`, specify only the host name: <hostname>. In a cloud environment, a VM name could be used as a host name. Example: `ip-12-34-56-78.us-west-2.compute.internal`.
 * `network_view`: optional, specifies the network view from which to get the specified network block. If a value is not specified, the default network view is considered. Example: `nview2`.
 * `dns_view`: optional, specifies the DNS view in which to create DNS resource records that are associated with the IP address. If a value is not specified, the default DNS view is considered. This parameter is relevant only when `enable_dns` is set to `true`. Example: `internal_view`.
 * `enable_dns`: optional, a flag that specifies whether DNS records associated with the resource must be created. The default value is `true`.
@@ -31,18 +32,18 @@ The following list describes the parameters you can define in the IP address all
 
 ```hcl
 resource "infoblox_ipv4_allocation" "alloc1" {
-  network_view="edge"
-  cidr="172.30.11.0/24" # this is to allocate
-                       # an IP address from the given network block
-  dns_view="default" # may be commented out
-  fqdn="test-vm.edge.example.com"
+  network_view = "edge"
+  cidr         = "172.30.11.0/24" # this is to allocate
+  # an IP address from the given network block
+  dns_view   = "default" # may be commented out
+  fqdn       = "test-vm.edge.example.com"
   enable_dns = "true"
-  comment = "Allocating an IPv4 address"
+  comment    = "Allocating an IPv4 address"
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"       = "tf-plugin"
     "Cloud API Owned" = "True"
-    "CMP Type"= "VMware"
-    "Site" = "Nevada"
+    "CMP Type"        = "VMware"
+    "Site"            = "Nevada"
   })
 }
 ```

--- a/docs/resources/infoblox_ipv4_association.md
+++ b/docs/resources/infoblox_ipv4_association.md
@@ -11,7 +11,7 @@ The `infoblox_ipv4_association` resource maps the IP address of a Host record cr
 The following list describes the parameters you can define in the resource block:
 
 * `fqdn`: required, specifies the name (in FQDN format) of a host for which an IP address needs to be allocated. When `enable_dns` is set to `true`, specify the zone name along with the host name in format: <hostname>.<zone>.
-  When `enable_dns` is set to `false`, specify only the host name: <hostname>. Example: ` ip-12-34-56-78.us-west-2.compute.internal`.
+  When `enable_dns` is set to `false`, specify only the host name: <hostname>. Example: `ip-12-34-56-78.us-west-2.compute.internal`.
 * `network_view`: optional, specifies the network view from which to get the specified network block. If a value is not specified, the default network view is considered. Example: `nview2`.
 * `dns_view`: optional, specifies the DNS view in which to create DNS resource records that are associated with the IP address. If a value is not specified, the default DNS view is considered. This parameter is relevant only when `enable_dns` is set to `true`. Example: `internal_view`.
 * `enable_dns`: optional, a flag that specifies whether DNS records associated with the resource must be created. The default value is `true`.
@@ -25,34 +25,35 @@ The following list describes the parameters you can define in the resource block
 ### Example of the Resource Block
 
 As the IP address association operation is dependent on the allocation operation, the following examples for IPv4 demonstrate how to define the resource blocks in the Terraform configuration file:
+
 ```hcl
-resource "infoblox_ipv4_allocation" "ipv4_allocation"{
-  network_view= "default"
-  cidr = infoblox_ipv4_network.ipv4_network.cidr
+resource "infoblox_ipv4_allocation" "ipv4_allocation" {
+  network_view = "default"
+  cidr         = infoblox_ipv4_network.ipv4_network.cidr
 
   #Create Host Record with DNS and DHCP flags
-  dns_view="default"
-  fqdn="testipv4.aws.com"
+  dns_view   = "default"
+  fqdn       = "testipv4.aws.com"
   enable_dns = "true"
   # The VM network interface’s MAC address is used.
   comment = "Allocating an IP address"
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"       = "tf-plugin"
     "Cloud API Owned" = "True"
-    "CMP Type"= "AWS"
-    "Site" = "Nevada"
+    "CMP Type"        = "AWS"
+    "Site"            = "Nevada"
   })
 }
 
-resource "infoblox_ipv4_association" "ipv4_associate"{
+resource "infoblox_ipv4_association" "ipv4_associate" {
   network_view = infoblox_ipv4_network.ipv4_network.network_view
-  dns_view=infoblox_ipv4_allocation.ipv4_allocation.dns_view
-  ip_addr = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
-  fqdn=infoblox_ipv4_allocation.ipv4_allocation.fqdn
-  enable_dns = infoblox_ipv4_allocation.ipv4_allocation.enable_dns
-  enable_dhcp = infoblox_ipv4_allocation.ipv4_allocation.enable_dhcp
-  mac_addr = aws_network_interface.ni.mac_address
-  comment = "Associating of an IPv4 address"
-  ext_attrs = infoblox_ipv4_allocation.ipv4_allocation.ext_attrs
+  dns_view     = infoblox_ipv4_allocation.ipv4_allocation.dns_view
+  ip_addr      = infoblox_ipv4_allocation.ipv4_allocation.ip_addr
+  fqdn         = infoblox_ipv4_allocation.ipv4_allocation.fqdn
+  enable_dns   = infoblox_ipv4_allocation.ipv4_allocation.enable_dns
+  enable_dhcp  = infoblox_ipv4_allocation.ipv4_allocation.enable_dhcp
+  mac_addr     = aws_network_interface.ni.mac_address
+  comment      = "Associating of an IPv4 address"
+  ext_attrs    = infoblox_ipv4_allocation.ipv4_allocation.ext_attrs
 }
 ```

--- a/docs/resources/infoblox_ipv4_network.md
+++ b/docs/resources/infoblox_ipv4_network.md
@@ -28,11 +28,11 @@ resource "infoblox_ipv4_network" "net1" {
 
 // full set of parameters for statically allocated IPv4 network
 resource "infoblox_ipv4_network" "net2" {
-  cidr = "10.1.0.0/24"
+  cidr         = "10.1.0.0/24"
   network_view = "nondefault_netview"
-  reserve_ip = 5
-  gateway = "10.1.0.254"
-  comment = "small network for testing"
+  reserve_ip   = 5
+  gateway      = "10.1.0.254"
+  comment      = "small network for testing"
   ext_attrs = jsonencode({
     "Site" = "bla-bla-bla... testing..."
   })
@@ -40,12 +40,12 @@ resource "infoblox_ipv4_network" "net2" {
 
 // full set of parameters for dynamically allocated IPv4 network
 resource "infoblox_ipv4_network" "net3" {
-  parent_cidr = infoblox_ipv4_network_container.v4net_c1.cidr // reference to the resource from another example
-  allocate_prefix_len = 26 // 24 (existing network container) + 2 (new network), prefix
-  network_view = "default" // we may omit this but it is not a mistake to specify explicitly
-  reserve_ip = 2
-  gateway = "none" // no gateway defined for this network
-  comment = "even smaller network for testing"
+  parent_cidr         = infoblox_ipv4_network_container.v4net_c1.cidr // reference to the resource from another example
+  allocate_prefix_len = 26                                            // 24 (existing network container) + 2 (new network), prefix
+  network_view        = "default"                                     // we may omit this but it is not a mistake to specify explicitly
+  reserve_ip          = 2
+  gateway             = "none" // no gateway defined for this network
+  comment             = "even smaller network for testing"
   ext_attrs = jsonencode({
     "Site" = "any place you wish ..."
   })

--- a/docs/resources/infoblox_ipv4_network_container.md
+++ b/docs/resources/infoblox_ipv4_network_container.md
@@ -27,23 +27,23 @@ resource "infoblox_ipv4_network_container" "v4net_c1" {
 
 // full set of parameters for statically allocated IPv4 network container
 resource "infoblox_ipv4_network_container" "v4net_c2" {
-  cidr = "10.2.0.0/24" // we may allocate the same IP address range but in another network view
+  cidr         = "10.2.0.0/24" // we may allocate the same IP address range but in another network view
   network_view = "nondefault_netview"
-  comment = "one of our clients"
+  comment      = "one of our clients"
   ext_attrs = jsonencode({
-    "Site" = "remote office"
+    "Site"    = "remote office"
     "Country" = "Australia"
   })
 }
 
 // full set of parameters for dynamic allocation of network containers
 resource "infoblox_ipv4_network_container" "v4net_c3" {
-  parent_cidr = infoblox_ipv4_network_container.v4net_c2.cidr
+  parent_cidr         = infoblox_ipv4_network_container.v4net_c2.cidr
   allocate_prefix_len = 26
-  network_view = infoblox_ipv4_network_container.v4net_c2.network_view
-  comment = "dynamic allocation of network container"
+  network_view        = infoblox_ipv4_network_container.v4net_c2.network_view
+  comment             = "dynamic allocation of network container"
   ext_attrs = jsonencode({
-    "Site" = "remote office"
+    "Site"    = "remote office"
     "Country" = "Australia"
   })
 }

--- a/docs/resources/infoblox_ipv6_allocation.md
+++ b/docs/resources/infoblox_ipv6_allocation.md
@@ -7,6 +7,7 @@ The `infoblox_ipv6_allocation` resource allows allocation of the next available 
 The allocation is done by creating a Host record in NIOS. The Host record can be created at the DNS server side by using the `enable_dns` flag, which is enabled by default. If you disable the flag, the record is not created in the DNS server side, but is visible on the IPAM tab in NIOS Grid Manager.
 
 When you create the Host record at the DNS server side, specify the host name in the FQDN format. The name must include the zone name and the host name as shown in the following example:
+
 ```
 enable_dns=true
 fqdn=hostname1.zone.com
@@ -17,7 +18,7 @@ If you disable the `enable_dns` flag, specify only the host name as FQDN. For ex
 The following list describes the parameters you can define in the IP address allocation resource blocks:
 
 * `fqdn`: required, specifies the name (in FQDN format) of a host for which an IP address needs to be allocated. When `enable_dns` is set to `true`, specify the zone name along with the host name in format: <hostname>.<zone>.
-  When `enable_dns` is set to `false`, specify only the host name: <hostname>. In a cloud environment, a VM name could be used as a host name. Example: ` ip-12-34-56-78.us-west-2.compute.internal`.
+  When `enable_dns` is set to `false`, specify only the host name: <hostname>. In a cloud environment, a VM name could be used as a host name. Example: `ip-12-34-56-78.us-west-2.compute.internal`.
 * `network_view`: optional, specifies the network view from which to get the specified network block. If a value is not specified, the default network view is considered. Example: `nview2`.
 * `dns_view`: optional, specifies the DNS view in which to create DNS resource records that are associated with the IP address. If a value is not specified, the default DNS view is considered. This parameter is relevant only when `enable_dns` is set to `true`. Example: `internal_view`.
 * `enable_dns`: optional, a flag that specifies whether DNS records associated with the resource must be created. The default value is `true`.
@@ -31,17 +32,17 @@ The following list describes the parameters you can define in the IP address all
 
 ```hcl
 resource "infoblox_ipv6_allocation" "alloc2" {
-  network_view="edge"
-  cidr="2a00:1148::/64" # this is to allocate
-                        # an IP address from the given network block 
-  fqdn="test-vm.edge.example.com"
+  network_view = "edge"
+  cidr         = "2a00:1148::/64" # this is to allocate
+  # an IP address from the given network block
+  fqdn       = "test-vm.edge.example.com"
   enable_dns = "true"
-  comment = "Allocating an IPv6 address"
+  comment    = "Allocating an IPv6 address"
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"       = "tf-plugin"
     "Cloud API Owned" = "True"
-    "CMP Type"= "VMware"
-    "Site" = "Nevada"
+    "CMP Type"        = "VMware"
+    "Site"            = "Nevada"
   })
 }
 ```

--- a/docs/resources/infoblox_ipv6_association.md
+++ b/docs/resources/infoblox_ipv6_association.md
@@ -11,7 +11,7 @@ The `infoblox_ipv6_association` resource maps the IP address of a Host record cr
 The following list describes the parameters you can define in the resource block:
 
 * `fqdn`: required, specifies the name (in FQDN format) of a host for which an IP address needs to be allocated. When `enable_dns` is set to `true`, specify the zone name along with the host name in format: <hostname>.<zone>.
-  When `enable_dns` is set to `false`, specify only the host name: <hostname>. Example: ` ip-12-34-56-78.us-west-2.compute.internal`.
+  When `enable_dns` is set to `false`, specify only the host name: <hostname>. Example: `ip-12-34-56-78.us-west-2.compute.internal`.
 * `network_view`: optional, specifies the network view from which to get the specified network block. If a value is not specified, the default network view is considered. Example: `nview2`.
 * `dns_view`: optional, specifies the DNS view in which to create DNS resource records that are associated with the IP address. If a value is not specified, the default DNS view is considered. This parameter is relevant only when `enable_dns` is set to `true`. Example: `internal_view`.
 * `enable_dns`: optional, a flag that specifies whether DNS records associated with the resource must be created. The default value is `true`.
@@ -28,47 +28,47 @@ As the IP address association operation is dependent on the allocation operation
 
 ```hcl
 resource "infoblox_ipv6_allocation" "ipv6_allocation" {
-  network_view= "default"
-  cidr = infoblox_ipv6_network.ipv6_network.cidr
-  
+  network_view = "default"
+  cidr         = infoblox_ipv6_network.ipv6_network.cidr
+
   #Create Host Record with DNS and DHCP flags
-  dns_view="default"
-  fqdn="testipv6.aws.com"
+  dns_view   = "default"
+  fqdn       = "testipv6.aws.com"
   enable_dns = "true"
 
   comment = "tf IPv6 allocation"
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"       = "tf-plugin"
     "Cloud API Owned" = "True"
-    "CMP Type"= "AWS"
-    "Network Name" = "ipv6-tf-network"
-    "VM Name" = "tf-ec2-instance-ipv6"
-    "Location" = "Test loc."
-    "Site" = "Test site"
-   })
+    "CMP Type"        = "AWS"
+    "Network Name"    = "ipv6-tf-network"
+    "VM Name"         = "tf-ec2-instance-ipv6"
+    "Location"        = "Test loc."
+    "Site"            = "Test site"
+  })
 }
 
-resource "infoblox_ipv6_association" "ipv6_associate"{
+resource "infoblox_ipv6_association" "ipv6_associate" {
   network_view = infoblox_ipv6_allocation.ipv6_allocation.network_view
-  ip_addr = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
-  duid = aws_network_interface.ni.mac_address
+  ip_addr      = infoblox_ipv6_allocation.ipv6_allocation.ip_addr
+  duid         = aws_network_interface.ni.mac_address
 
   #Create Host Record with DNS and DHCP flags
-  dns_view=infoblox_ipv6_allocation.ipv6_allocation.dns_view
-  fqdn=infoblox_ipv6_allocation.ipv6_allocation.fqdn
-  enable_dns = infoblox_ipv6_allocation.ipv6_allocation.enable_dns
+  dns_view    = infoblox_ipv6_allocation.ipv6_allocation.dns_view
+  fqdn        = infoblox_ipv6_allocation.ipv6_allocation.fqdn
+  enable_dns  = infoblox_ipv6_allocation.ipv6_allocation.enable_dns
   enable_dhcp = infoblox_ipv6_allocation.ipv6_allocation.enable_dhcp
 
-  comment = ""Associating of an IPv6 address""
+  comment = "Associating of an IPv6 address"
   ext_attrs = jsonencode({
-    "Tenant ID" = "tf-plugin"
+    "Tenant ID"       = "tf-plugin"
     "Cloud API Owned" = "True"
-    "CMP Type"= "AWS"
-    "Network Name" = "ipv6-tf-network"
-    "VM Name" = "tf-ec2-instance-ipv6"
-    "VM ID" = aws_instance.ec2-instance.id
-    "Location" = "Test loc."
-    "Site" = "Test site"
+    "CMP Type"        = "AWS"
+    "Network Name"    = "ipv6-tf-network"
+    "VM Name"         = "tf-ec2-instance-ipv6"
+    "VM ID"           = aws_instance.ec2-instance.id
+    "Location"        = "Test loc."
+    "Site"            = "Test site"
   })
 }
 ```

--- a/docs/resources/infoblox_ipv6_network.md
+++ b/docs/resources/infoblox_ipv6_network.md
@@ -28,11 +28,11 @@ resource "infoblox_ipv6_network" "net1" {
 
 // full set of parameters for statically allocated IPv6 network
 resource "infoblox_ipv6_network" "net2" {
-  cidr = "2002:1f93:0:4::/96"
+  cidr         = "2002:1f93:0:4::/96"
   network_view = "nondefault_netview"
   reserve_ipv6 = 10
-  gateway = "2002:1f93:0:4::1"
-  comment = "let's try IPv6"
+  gateway      = "2002:1f93:0:4::1"
+  comment      = "let's try IPv6"
   ext_attrs = jsonencode({
     "Site" = "somewhere in Antarctica"
   })
@@ -40,12 +40,12 @@ resource "infoblox_ipv6_network" "net2" {
 
 // full set of parameters for dynamically allocated IPv6 network
 resource "infoblox_ipv6_network" "net3" {
-  parent_cidr = infoblox_ipv6_network_container.v6net_c1.cidr // reference to the resource from another example
-  allocate_prefix_len = 100 // 96 (existing network container) + 4 (new network), prefix
-  network_view = "default" // we may omit this but it is not a mistake to specify explicitly
-  reserve_ipv6 = 20
-  gateway = "none" // no gateway defined for this network
-  comment = "the network for the Test Lab"
+  parent_cidr         = infoblox_ipv6_network_container.v6net_c1.cidr // reference to the resource from another example
+  allocate_prefix_len = 100                                           // 96 (existing network container) + 4 (new network), prefix
+  network_view        = "default"                                     // we may omit this but it is not a mistake to specify explicitly
+  reserve_ipv6        = 20
+  gateway             = "none" // no gateway defined for this network
+  comment             = "the network for the Test Lab"
   ext_attrs = jsonencode({
     "Site" = "small inner cluster"
   })

--- a/docs/resources/infoblox_ipv6_network_container.md
+++ b/docs/resources/infoblox_ipv6_network_container.md
@@ -27,24 +27,24 @@ resource "infoblox_ipv6_network_container" "v6net_c1" {
 
 // full set of parameters for statically allocated IPv6 network container
 resource "infoblox_ipv6_network_container" "v6net_c2" {
-  cidr = "2002:1f93:0:2::/96"
+  cidr         = "2002:1f93:0:2::/96"
   network_view = "nondefault_netview"
-  comment = "new generation network segment"
+  comment      = "new generation network segment"
   ext_attrs = jsonencode({
-    "Site" = "space station"
+    "Site"    = "space station"
     "Country" = "Earth orbit"
   })
 }
 
 // full set of parameters for dynamic allocation of network containers
 resource "infoblox_ipv6_network_container" "v6net_c3" {
-  parent_cidr = infoblox_ipv6_network_container.v6net_c2.cidr
+  parent_cidr         = infoblox_ipv6_network_container.v6net_c2.cidr
   allocate_prefix_len = 97
-  network_view = infoblox_ipv6_network_container.v6net_c2.network_view
-  comment = "dynamic allocation of network container"
+  network_view        = infoblox_ipv6_network_container.v6net_c2.network_view
+  comment             = "dynamic allocation of network container"
   ext_attrs = jsonencode({
     "Tenant ID" = "terraform_test_tenant"
-    Site = "Test site"
+    Site        = "Test site"
   })
 }
 ```

--- a/docs/resources/infoblox_mx_record.md
+++ b/docs/resources/infoblox_mx_record.md
@@ -18,19 +18,19 @@ The following list describes the parameters you can define in the resource block
 ```hcl
 // MX-record, minimal set of parameters
 resource "infoblox_mx_record" "rec1" {
-  fqdn = "big-big-company.com"
+  fqdn           = "big-big-company.com"
   mail_exchanger = "mx1.secure-mail-provider.net"
-  preference = 30
+  preference     = 30
 }
 
 // MX-record, full set of parameters
 resource "infoblox_mx_record" "rec2" {
-  dns_view = "nondefault_dnsview1"
-  fqdn = "rec2.example2.org"
+  dns_view       = "nondefault_dnsview1"
+  fqdn           = "rec2.example2.org"
   mail_exchanger = "sample.test.com"
-  preference = 40
-  comment = "example MX-record"
-  ttl = 120
+  preference     = 40
+  comment        = "example MX-record"
+  ttl            = 120
   ext_attrs = jsonencode({
     "Location" = "Las Vegas"
   })

--- a/docs/resources/infoblox_network_view.md
+++ b/docs/resources/infoblox_network_view.md
@@ -19,7 +19,7 @@ the resource block.
 
 ```hcl
 resource "infoblox_network_view" "netview1234" {
-  name = "one_more_network_view"
+  name    = "one_more_network_view"
   comment = "example network view"
   ext_attrs = jsonencode({
     "Location" = "the North pole"

--- a/docs/resources/infoblox_ptr_record.md
+++ b/docs/resources/infoblox_ptr_record.md
@@ -6,8 +6,8 @@ The following list describes the parameters you can define for the `infoblox_ptr
 
 * `ptrdname`: required, specifies the domain name in the FQDN format to which the record should point to. Example: `host1.example.com`.
 * `ip_addr`: required only for static allocation in reverse-mapping zones, specifies the IPv4 or IPv6 address for record creation in reverse-mapping zone. Example: `82.50.36.8`.
-    * For allocating a static IP address, specify a valid IP address.
-    * For allocating a dynamic IP address, do not use this field. Instead, define the `cidr` field.
+  * For allocating a static IP address, specify a valid IP address.
+  * For allocating a dynamic IP address, do not use this field. Instead, define the `cidr` field.
 * `cidr`: required only for dynamic allocation in reverse-mapping zones, specifies the network address in CIDR format, under which the record must be created. For static allocation, do not use this field. Instead, define the `ip_addr` field. Example: `10.3.128.0/20`.
 * `network_view`: optional, specifies the network view to use when allocating an IP address from a network dynamically. If a value is not specified, the name `default` is used as the network view. For static allocation, do not use this field. Example: `netview1`.
 * `dns_view`: optional, specifies the DNS view in which the zone exists. If a value is not specified, the name `default` is used as the DNS view. Example: `external_dnsview`.
@@ -30,11 +30,11 @@ The following list describes the parameters you can define for the `infoblox_ptr
 //   2) 'record_name' - in the form of a domain name (ex. 1.0.0.10.in-addr.arpa)
 resource "infoblox_ptr_record" "ptr1" {
   ptrdname = "rec1.example1.org"
-  ip_addr = "10.0.0.1"
+  ip_addr  = "10.0.0.1"
 }
 
 resource "infoblox_ptr_record" "ptr2" {
-  ptrdname = "rec2.example1.org"
+  ptrdname    = "rec2.example1.org"
   record_name = "2.0.0.10.in-addr.arpa"
 }
 
@@ -42,9 +42,9 @@ resource "infoblox_ptr_record" "ptr2" {
 resource "infoblox_ptr_record" "ptr3" {
   ptrdname = "rec3.example2.org"
   dns_view = "nondefault_dnsview1"
-  ip_addr = "2002:1f93::3"
-  comment = "workstation #3"
-  ttl = 300 # 5 minutes
+  ip_addr  = "2002:1f93::3"
+  comment  = "workstation #3"
+  ttl      = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -53,17 +53,17 @@ resource "infoblox_ptr_record" "ptr3" {
 // dynamically allocated PTR-record, minimal set of parameters
 resource "infoblox_ptr_record" "ptr4" {
   ptrdname = "rec4.example2.org"
-  cidr = "10.0.0.0/16"
+  cidr     = "10.0.0.0/16"
 }
 
 // dynamically allocated PTR-record, full set of parameters, non-default network view
 resource "infoblox_ptr_record" "ptr5" {
-  ptrdname = "rec5.example2.org"
-  dns_view = "nondefault_dnsview2"
+  ptrdname     = "rec5.example2.org"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview"
-  cidr = "10.1.0.0/24"
-  comment = "workstation #5"
-  ttl = 300 # 5 minutes
+  cidr         = "10.1.0.0/24"
+  comment      = "workstation #5"
+  ttl          = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -71,7 +71,7 @@ resource "infoblox_ptr_record" "ptr5" {
 
 // PTR-record in a forward-mapping zone
 resource "infoblox_ptr_record" "ptr6_forward" {
-  ptrdname = "example1.org"
+  ptrdname    = "example1.org"
   record_name = "www.example1.org"
 }
 ```

--- a/docs/resources/infoblox_srv_record.md
+++ b/docs/resources/infoblox_srv_record.md
@@ -20,25 +20,25 @@ The following list describes the parameters you can define in the resource block
 ```hcl
 // minimal set of parameters
 resource "infoblox_srv_record" "rec1" {
-    name = "_http._tcp.example.org"
-    priority = 100
-    weight = 75
-    port = 8080
-    target = "www.example.org"
-} 
+  name     = "_http._tcp.example.org"
+  priority = 100
+  weight   = 75
+  port     = 8080
+  target   = "www.example.org"
+}
 
 // all set of parameters for SRV record
 resource "infoblox_srv_record" "rec2" {
-    dns_view = "nondefault_dnsview1"
-    name = "_sip._udp.example2.org"
-    priority = 12
-    weight = 10
-    port = 5060
-    target = "sip.example2.org"
-    ttl = 3600
-    comment = "example SRV record"
-    ext_attrs = jsonencode({
-        "Location" = "65.8665701230204, -37.00791763398113"
-    })
+  dns_view = "nondefault_dnsview1"
+  name     = "_sip._udp.example2.org"
+  priority = 12
+  weight   = 10
+  port     = 5060
+  target   = "sip.example2.org"
+  ttl      = 3600
+  comment  = "example SRV record"
+  ext_attrs = jsonencode({
+    "Location" = "65.8665701230204, -37.00791763398113"
+  })
 }
 ```

--- a/docs/resources/infoblox_txt_record.md
+++ b/docs/resources/infoblox_txt_record.md
@@ -23,18 +23,18 @@ resource "infoblox_txt_record" "rec1" {
 // some parameters for a TXT-Record
 resource "infoblox_txt_record" "rec2" {
   dns_view = "default" // may be omitted
-  fqdn = "sample2.example.org"
-  text = "\"data for TXT-record #2\""
-  ttl = 120 // 120s
+  fqdn     = "sample2.example.org"
+  text     = "\"data for TXT-record #2\""
+  ttl      = 120 // 120s
 }
 
 // all the parameters for a TXT-Record
 resource "infoblox_txt_record" "rec3" {
   dns_view = "nondefault_dnsview1"
-  fqdn = "example3.example2.org"
-  text = "\"data for TXT-record #3\""
-  ttl = 300
-  comment = "example TXT record #3"
+  fqdn     = "example3.example2.org"
+  text     = "\"data for TXT-record #3\""
+  ttl      = 300
+  comment  = "example TXT record #3"
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })

--- a/docs/resources/infoblox_zone_auth.md
+++ b/docs/resources/infoblox_zone_auth.md
@@ -26,10 +26,10 @@ Example: `10.1.0.0/24` for reverse zone and `zone1.com` for forward zone.
 ```hcl
 //forward mapping zone, with minimal set of parameters
 resource "infoblox_zone_auth" "zone1" {
-  fqdn = "test3.com"
-  view = "default"
+  fqdn        = "test3.com"
+  view        = "default"
   zone_format = "FORWARD"
-  comment = "Zone Auth created newly"
+  comment     = "Zone Auth created newly"
   ext_attrs = jsonencode({
     Location = "AcceptanceTerraform"
   })
@@ -37,17 +37,17 @@ resource "infoblox_zone_auth" "zone1" {
 
 //IPV4 reverse mapping zone, with full set of parameters
 resource "infoblox_zone_auth" "zone2" {
-  fqdn = "10.0.0.0/24"
-  view = "default"
-  zone_format = "IPV4"
-  ns_group = "nsgroup1"
+  fqdn              = "10.0.0.0/24"
+  view              = "default"
+  zone_format       = "IPV4"
+  ns_group          = "nsgroup1"
   restart_if_needed = true
-  soa_default_ttl = 37000
-  soa_expire = 92000
-  soa_negative_ttl = 900
-  soa_refresh = 2100
-  soa_retry = 800
-  comment = "IPV4 reverse zone auth created"
+  soa_default_ttl   = 37000
+  soa_expire        = 92000
+  soa_negative_ttl  = 900
+  soa_refresh       = 2100
+  soa_retry         = 800
+  comment           = "IPV4 reverse zone auth created"
   ext_attrs = jsonencode({
     Location = "TestTerraform"
   })
@@ -55,14 +55,13 @@ resource "infoblox_zone_auth" "zone2" {
 
 //IPV6 reverse mapping zone, with minimal set of parameters
 resource "infoblox_zone_auth" "zone3" {
-  fqdn = "2002:1100::/64"
-  view = "non_defaultview"
+  fqdn        = "2002:1100::/64"
+  view        = "non_defaultview"
   zone_format = "IPV6"
-  ns_group = "nsgroup2"
-  comment = "IPV6 reverse zone auth created"
+  ns_group    = "nsgroup2"
+  comment     = "IPV6 reverse zone auth created"
   ext_attrs = jsonencode({
     Location = "Random TF location"
   })
 }
 ```
-

--- a/docs/resources/infoblox_zone_forward.md
+++ b/docs/resources/infoblox_zone_forward.md
@@ -14,13 +14,16 @@ The following list describes the parameters you can define in the resource block
 * `disable`: optional, specifies whether the zone is disabled. Default value: `false`.
 * `forwarders_only`: optional, specifies whether the appliance sends queries to forwarders only, and not to other internal or Internet root servers. Default value: `false`.
 * `forward_to`: Required if external_ns_group is not configured. Determines the information for the remote name servers to which you want the Infoblox appliance to forward queries for a specified domain name. Example:
+
 ```terraform
 forward_to {
     name = "te32.dz.ex.com"
     address = "10.0.0.1"
   }
 ```
+
 * `forwarding_servers`: optional, determines the information for the Grid members to which you want the Infoblox appliance to forward queries for a specified domain name. Example:
+
 ```terraform
 forwarding_servers {
     name = "infoblox.172_28_83_0"
@@ -32,13 +35,13 @@ forwarding_servers {
     }
   }
 ```
+
 * `comment`: optional, description of the zone. Example: `custom forward zone`.
 * `ext_attrs`: optional, set of the Extensible attributes of the zone, as a map in JSON format. Example: `jsonencode({})`.
 
 !> For a reverse zone, the corresponding 'zone_format' value should be set. And 'fqdn' once set cannot be updated.
->**Note**: Either define forwarding_servers or ns_group. 
+>**Note**: Either define forwarding_servers or ns_group.
 > If both the parameters are configured, settings of ns_group takes precedence.
-
 
 ### Examples of a Zone Forward Block
 
@@ -47,40 +50,40 @@ forwarding_servers {
 resource "infoblox_zone_forward" "forward_zone_forwardTo" {
   fqdn = "min_params.ex.org"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
 }
 
 //forward zone with full set of parameters
 resource "infoblox_zone_forward" "forward_zone_full_parameters" {
-  fqdn = "max_params.ex.org"
-  view = "nondefault_view"
+  fqdn        = "max_params.ex.org"
+  view        = "nondefault_view"
   zone_format = "FORWARD"
-  comment = "test sample forward zone"
+  comment     = "test sample forward zone"
   forward_to {
-    name = "te32.dz.ex.com"
+    name    = "te32.dz.ex.com"
     address = "10.0.0.1"
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_216"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_216"
+    forwarders_only         = true
     use_override_forwarders = false
     forward_to {
-      name = "cc.fwd.com"
+      name    = "cc.fwd.com"
       address = "10.1.1.1"
     }
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_0"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_0"
+    forwarders_only         = true
     use_override_forwarders = true
     forward_to {
-      name = "kk.fwd.com"
+      name    = "kk.fwd.com"
       address = "10.2.1.31"
     }
   }
@@ -88,12 +91,11 @@ resource "infoblox_zone_forward" "forward_zone_full_parameters" {
 
 //forward zone with ns_group, external_ns_group and extra attribute Site
 resource "infoblox_zone_forward" "forward_zone_nsGroup_externalNsGroup" {
-  fqdn = "params_ns_ens.ex.org"
-  ns_group = "test"
+  fqdn              = "params_ns_ens.ex.org"
+  ns_group          = "test"
   external_ns_group = "stub server"
   ext_attrs = jsonencode({
     "Site" = "Antarctica"
   })
 }
 ```
-

--- a/examples/datasources/infoblox_a_record.tf
+++ b/examples/datasources/infoblox_a_record.tf
@@ -1,9 +1,9 @@
 resource "infoblox_a_record" "vip_host" {
-  fqdn = "very-interesting-host.example.com"
-  ip_addr = "10.3.1.65"
-  comment = "special host"
+  fqdn     = "very-interesting-host.example.com"
+  ip_addr  = "10.3.1.65"
+  comment  = "special host"
   dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  ttl      = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -12,9 +12,9 @@ resource "infoblox_a_record" "vip_host" {
 
 data "infoblox_a_record" "a_rec_temp" {
   filters = {
-    name = "very-interesting-host.example.com"
+    name     = "very-interesting-host.example.com"
     ipv4addr = "10.3.1.65" //alias is ip_addr
-    view = "nondefault_dnsview2"
+    view     = "nondefault_dnsview2"
   }
 
   // This is just to ensure that the record has been be created

--- a/examples/datasources/infoblox_aaaa_record.tf
+++ b/examples/datasources/infoblox_aaaa_record.tf
@@ -1,8 +1,8 @@
 resource "infoblox_aaaa_record" "vip_host" {
-  fqdn = "very-interesting-host.example.com"
+  fqdn      = "very-interesting-host.example.com"
   ipv6_addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
-  comment = "some comment"
-  ttl = 120 // 120s
+  comment   = "some comment"
+  ttl       = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -10,8 +10,8 @@ resource "infoblox_aaaa_record" "vip_host" {
 
 data "infoblox_aaaa_record" "qa_rec_temp" {
   filters = {
-    name ="very-interesting-host.example.com"
-    ipv6addr ="2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+    name     = "very-interesting-host.example.com"
+    ipv6addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
   }
 
   // This is just to ensure that the record has been be created

--- a/examples/datasources/infoblox_cname_record.tf
+++ b/examples/datasources/infoblox_cname_record.tf
@@ -1,20 +1,20 @@
 resource "infoblox_cname_record" "foo" {
-  dns_view = "default.nondefault_netview"
+  dns_view  = "default.nondefault_netview"
   canonical = "strange-place.somewhere.in.the.net"
-  alias = "foo.test.com"
-  comment = "we need to keep an eye on this strange host"
-  ttl = 0 // disable caching
+  alias     = "foo.test.com"
+  comment   = "we need to keep an eye on this strange host"
+  ttl       = 0 // disable caching
   ext_attrs = jsonencode({
-    Site = "unknown"
+    Site     = "unknown"
     Location = "TBD"
   })
 }
 
-data "infoblox_cname_record" "cname_rec"{
+data "infoblox_cname_record" "cname_rec" {
   filters = {
-    name = "foo.test.com"
+    name      = "foo.test.com"
     canonical = "strange-place.somewhere.in.the.net"
-    view = "default.nondefault_netview"
+    view      = "default.nondefault_netview"
   }
 
   // This is just to ensure that the record has been be created

--- a/examples/datasources/infoblox_dns_view.tf
+++ b/examples/datasources/infoblox_dns_view.tf
@@ -1,5 +1,5 @@
 resource "infoblox_dns_view" "view1" {
-  name = "test_blog"
+  name    = "test_blog"
   comment = "strange test dnsview"
   ext_attrs = jsonencode({
     "Site" = "New Location"

--- a/examples/datasources/infoblox_host_record.tf
+++ b/examples/datasources/infoblox_host_record.tf
@@ -4,22 +4,22 @@ resource "infoblox_zone_auth" "zone1" {
 }
 
 resource "infoblox_ip_allocation" "allocation1" {
-  dns_view = "default"
+  dns_view   = "default"
   enable_dns = true
-  fqdn = "host1.example.org"
-  ipv4_addr = "10.10.0.7"
-  ipv6_addr = "1::1"
-  ext_attrs = jsonencode({"Location" = "USA"})
+  fqdn       = "host1.example.org"
+  ipv4_addr  = "10.10.0.7"
+  ipv6_addr  = "1::1"
+  ext_attrs  = jsonencode({ "Location" = "USA" })
 
   depends_on = [infoblox_zone_auth.zone1]
 }
 
 resource "infoblox_ip_association" "association1" {
   internal_id = infoblox_ip_allocation.allocation1.id
-  mac_addr = "12:00:43:fe:9a:8c"
-  duid = "12:00:43:fe:9a:81"
+  mac_addr    = "12:00:43:fe:9a:8c"
+  duid        = "12:00:43:fe:9a:81"
   enable_dhcp = false
-  depends_on = [infoblox_ip_allocation.allocation1]
+  depends_on  = [infoblox_ip_allocation.allocation1]
 }
 
 data "infoblox_host_record" "host_rec_temp" {

--- a/examples/datasources/infoblox_ipv4_network.tf
+++ b/examples/datasources/infoblox_ipv4_network.tf
@@ -1,6 +1,6 @@
 data "infoblox_ipv4_network" "net1" {
   filters = {
-    network = "10.1.0.0/24"
+    network      = "10.1.0.0/24"
     network_view = "nondefault_netview"
   }
 

--- a/examples/datasources/infoblox_ipv4_network_container.tf
+++ b/examples/datasources/infoblox_ipv4_network_container.tf
@@ -1,6 +1,6 @@
 data "infoblox_ipv4_network_container" "nc2" {
   filters = {
-    network = "10.2.0.0/24"
+    network      = "10.2.0.0/24"
     network_view = "nondefault_netview"
   }
 

--- a/examples/datasources/infoblox_ipv6_network.tf
+++ b/examples/datasources/infoblox_ipv6_network.tf
@@ -1,8 +1,8 @@
 resource "infoblox_ipv6_network" "ipv6net1" {
-  cidr = "2002:1f93:0:4::/96"
+  cidr         = "2002:1f93:0:4::/96"
   reserve_ipv6 = 10
-  gateway = "2002:1f93:0:4::1"
-  comment = "let's try IPv6"
+  gateway      = "2002:1f93:0:4::1"
+  comment      = "let's try IPv6"
   ext_attrs = jsonencode({
     "Site" = "Antarctica"
   })

--- a/examples/datasources/infoblox_ipv6_network_container.tf
+++ b/examples/datasources/infoblox_ipv6_network_container.tf
@@ -1,5 +1,5 @@
 resource "infoblox_ipv6_network_container" "nc1" {
-  cidr = "2002:1f93:0:2::/96"
+  cidr    = "2002:1f93:0:2::/96"
   comment = "new generation network segment"
   ext_attrs = jsonencode({
     "Site" = "space station"

--- a/examples/datasources/infoblox_mx_record.tf
+++ b/examples/datasources/infoblox_mx_record.tf
@@ -1,27 +1,27 @@
 resource "infoblox_mx_record" "rec2" {
-    dns_view = "nondefault_dnsview1"
-    fqdn = "rec2.example2.org"
-    mail_exchanger = "sample.test.com"
-    preference = 40
-    comment = "example MX-record"
-    ttl = 120
-    ext_attrs = jsonencode({
-        "Location" = "Las Vegas"
-    })
+  dns_view       = "nondefault_dnsview1"
+  fqdn           = "rec2.example2.org"
+  mail_exchanger = "sample.test.com"
+  preference     = 40
+  comment        = "example MX-record"
+  ttl            = 120
+  ext_attrs = jsonencode({
+    "Location" = "Las Vegas"
+  })
 }
 
 data "infoblox_mx_record" "ds2" {
-    filters = {
-        view = "nondefault_dnsview1"
-        name = "rec2.example2.org"
-        mail_exchanger = "sample.test.com"
-    }
+  filters = {
+    view           = "nondefault_dnsview1"
+    name           = "rec2.example2.org"
+    mail_exchanger = "sample.test.com"
+  }
 
-    // This is just to ensure that the record has been be created
-    // using 'infoblox_mx_record' resource block before the data source will be queried.
-    depends_on = [infoblox_mx_record.rec2]
+  // This is just to ensure that the record has been be created
+  // using 'infoblox_mx_record' resource block before the data source will be queried.
+  depends_on = [infoblox_mx_record.rec2]
 }
 
 output "mx_rec_res" {
-    value = data.infoblox_mx_record.ds2
+  value = data.infoblox_mx_record.ds2
 }

--- a/examples/datasources/infoblox_network_view.tf
+++ b/examples/datasources/infoblox_network_view.tf
@@ -1,5 +1,5 @@
 resource "infoblox_network_view" "inet_nv" {
-  name = "inet_visible_nv"
+  name    = "inet_visible_nv"
   comment = "Internet-facing networks"
   ext_attrs = jsonencode({
     "Location" = "the North pole"

--- a/examples/datasources/infoblox_ptr_record.tf
+++ b/examples/datasources/infoblox_ptr_record.tf
@@ -1,8 +1,8 @@
 resource "infoblox_ptr_record" "host1" {
   ptrdname = "host.example.org"
-  ip_addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
-  comment = "workstation #3"
-  ttl = 300 # 5 minutes
+  ip_addr  = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+  comment  = "workstation #3"
+  ttl      = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -10,8 +10,8 @@ resource "infoblox_ptr_record" "host1" {
 
 data "infoblox_ptr_record" "host1" {
   filters = {
-    ptrdname="host.example.org"
-    ipv6addr="2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
+    ptrdname = "host.example.org"
+    ipv6addr = "2a05:d014:275:cb00:ec0d:12e2:df27:aa60"
   }
 
   // This is just to ensure that the record has been be created

--- a/examples/datasources/infoblox_srv_record.tf
+++ b/examples/datasources/infoblox_srv_record.tf
@@ -1,30 +1,30 @@
 resource "infoblox_srv_record" "rec2" {
-    dns_view = "nondefault_dnsview1"
-    name = "_sip._udp.example2.org"
-    priority = 12
-    weight = 10
-    port = 5060
-    target = "sip.example2.org"
-    ttl = 3600
-    comment = "example SRV record"
-    ext_attrs = jsonencode({
-        "Location" = "65.8665701230204, -37.00791763398113"
-    })
+  dns_view = "nondefault_dnsview1"
+  name     = "_sip._udp.example2.org"
+  priority = 12
+  weight   = 10
+  port     = 5060
+  target   = "sip.example2.org"
+  ttl      = 3600
+  comment  = "example SRV record"
+  ext_attrs = jsonencode({
+    "Location" = "65.8665701230204, -37.00791763398113"
+  })
 }
 
 data "infoblox_srv_record" "ds1" {
-    filters = {
-        view = "nondefault_dnsview1"
-        name = "_sip._udp.example2.org"
-        port = 5060
-        target = "sip.example2.org"
-    }
+  filters = {
+    view   = "nondefault_dnsview1"
+    name   = "_sip._udp.example2.org"
+    port   = 5060
+    target = "sip.example2.org"
+  }
 
-    // This is just to ensure that the record has been be created
-    // using 'infoblox_srv_record' resource block before the data source will be queried.
-    depends_on = [infoblox_srv_record.rec2]
+  // This is just to ensure that the record has been be created
+  // using 'infoblox_srv_record' resource block before the data source will be queried.
+  depends_on = [infoblox_srv_record.rec2]
 }
 
 output "srv_rec_res" {
-    value = data.infoblox_srv_record.ds1
+  value = data.infoblox_srv_record.ds1
 }

--- a/examples/datasources/infoblox_txt_record.tf
+++ b/examples/datasources/infoblox_txt_record.tf
@@ -1,16 +1,16 @@
 resource "infoblox_txt_record" "rec3" {
   dns_view = "nondefault_dnsview1"
-  fqdn = "example3.example2.org"
-  text = "\"data for TXT-record #3\""
-  ttl = 300
-  comment = "example TXT record #3"
+  fqdn     = "example3.example2.org"
+  text     = "\"data for TXT-record #3\""
+  ttl      = 300
+  comment  = "example TXT record #3"
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
 }
 
 data "infoblox_txt_record" "ds3" {
-  filters =  {
+  filters = {
     view = "nondefault_dnsview1"
     name = "example3.example2.org"
   }

--- a/examples/datasources/infoblox_zone_auth.tf
+++ b/examples/datasources/infoblox_zone_auth.tf
@@ -1,10 +1,10 @@
-resource "infoblox_zone_auth" "zone1"{
-  fqdn = "17.1.0.0/16"
+resource "infoblox_zone_auth" "zone1" {
+  fqdn        = "17.1.0.0/16"
   zone_format = "IPV4"
-  view = "default"
-  comment = "test sample reverse zone"
+  view        = "default"
+  comment     = "test sample reverse zone"
   ext_attrs = jsonencode({
-    Location =  "Test Zone Location"
+    Location = "Test Zone Location"
   })
 }
 //EA search example for Zone Auth datasource
@@ -18,8 +18,8 @@ data "infoblox_zone_auth" "dzone1" {
 //Generic example using filters, Zone Auth datasource
 data "infoblox_zone_auth" "acctest" {
   filters = {
-    view = "default"
-    fqdn = infoblox_zone_auth.zone1.fqdn
+    view        = "default"
+    fqdn        = infoblox_zone_auth.zone1.fqdn
     zone_format = "IPV4"
   }
 }

--- a/examples/datasources/infoblox_zone_forward.tf
+++ b/examples/datasources/infoblox_zone_forward.tf
@@ -1,11 +1,11 @@
 resource "infoblox_zone_forward" "forwardzone_forwardTo" {
   fqdn = "zone_forward.ex.org"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
 }
@@ -27,18 +27,18 @@ output "zone_forward_data3" {
 
 
 resource "infoblox_zone_forward" "forwardzone_IPV4_nsGroup_externalNsGroup" {
-  fqdn = "195.1.0.0/24"
-  comment = "Forward zone IPV4"
+  fqdn              = "195.1.0.0/24"
+  comment           = "Forward zone IPV4"
   external_ns_group = "stub server"
-  zone_format = "IPV4"
-  ns_group = "test"
+  zone_format       = "IPV4"
+  ns_group          = "test"
 }
 
 // accessing Zone Forward by specifying fqdn, view and comment
 data "infoblox_zone_forward" "datazone_foward_fqdn_view_comment" {
   filters = {
-    fqdn = "195.1.0.0/24"
-    view = "default"
+    fqdn    = "195.1.0.0/24"
+    view    = "default"
     comment = "Forward zone IPV4"
   }
   // This is just to ensure that the record has been be created

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,5 +1,5 @@
 provider "infoblox" {
-  server = "172.17.0.2"
+  server   = "172.17.0.2"
   username = "admin"
   password = "infoblox"
 }

--- a/examples/resources/infoblox_a_record.tf
+++ b/examples/resources/infoblox_a_record.tf
@@ -1,16 +1,16 @@
 // static A-record, minimal set of parameters
 resource "infoblox_a_record" "rec1" {
-  fqdn = "static1.example1.org"
+  fqdn    = "static1.example1.org"
   ip_addr = "1.3.5.4" // not necessarily from a network existing in NIOS DB
 }
 
 // all the parameters for a static A-record
 resource "infoblox_a_record" "rec2" {
-  fqdn = "static2.example4.org"
-  ip_addr = "1.3.5.1"
-  comment = "example static A-record rec2"
+  fqdn     = "static2.example4.org"
+  ip_addr  = "1.3.5.1"
+  comment  = "example static A-record rec2"
   dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  ttl      = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -18,11 +18,11 @@ resource "infoblox_a_record" "rec2" {
 
 // all the parameters for a dynamic A-record
 resource "infoblox_a_record" "rec3" {
-  fqdn = "dynamic1.example2.org"
-  cidr = infoblox_ipv4_network.net2.cidr // the network  must exist, you may use the example for infoblox_ipv4_network resource.
+  fqdn         = "dynamic1.example2.org"
+  cidr         = infoblox_ipv4_network.net2.cidr         // the network  must exist, you may use the example for infoblox_ipv4_network resource.
   network_view = infoblox_ipv4_network.net2.network_view // not necessarily in the same network view as the DNS view resides in.
-  comment = "example dynamic A-record rec3"
-  dns_view = "nondefault_dnsview1"
-  ttl = 0 // 0 = disable caching
-  ext_attrs = jsonencode({})
+  comment      = "example dynamic A-record rec3"
+  dns_view     = "nondefault_dnsview1"
+  ttl          = 0 // 0 = disable caching
+  ext_attrs    = jsonencode({})
 }

--- a/examples/resources/infoblox_aaaa_record.tf
+++ b/examples/resources/infoblox_aaaa_record.tf
@@ -1,16 +1,16 @@
 // static AAAA-record, minimal set of parameters
 resource "infoblox_aaaa_record" "rec1" {
-  fqdn = "static1.example1.org"
+  fqdn      = "static1.example1.org"
   ipv6_addr = "2002:1111::1401" // not necessarily from a network existing in NIOS DB
 }
 
 // all the parameters for a static AAAA-record
 resource "infoblox_aaaa_record" "rec2" {
-  fqdn = "static2.example4.org"
+  fqdn      = "static2.example4.org"
   ipv6_addr = "2002:1111::1402"
-  comment = "example static AAAA-record rec2"
-  dns_view = "nondefault_dnsview2"
-  ttl = 120 // 120s
+  comment   = "example static AAAA-record rec2"
+  dns_view  = "nondefault_dnsview2"
+  ttl       = 120 // 120s
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })
@@ -18,11 +18,11 @@ resource "infoblox_aaaa_record" "rec2" {
 
 // all the parameters for a dynamic AAAA-record
 resource "infoblox_aaaa_record" "rec3" {
-  fqdn = "dynamic1.example2.org"
-  cidr = infoblox_ipv6_network.net2.cidr // the network  must exist, you may use the example for infoblox_ipv6_network resource.
+  fqdn         = "dynamic1.example2.org"
+  cidr         = infoblox_ipv6_network.net2.cidr         // the network  must exist, you may use the example for infoblox_ipv6_network resource.
   network_view = infoblox_ipv6_network.net2.network_view // not necessarily in the same network view as the DNS view resides in.
-  comment = "example dynamic AAAA-record rec3"
-  dns_view = "nondefault_dnsview1"
-  ttl = 0 // 0 = disable caching
-  ext_attrs = jsonencode({})
+  comment      = "example dynamic AAAA-record rec3"
+  dns_view     = "nondefault_dnsview1"
+  ttl          = 0 // 0 = disable caching
+  ext_attrs    = jsonencode({})
 }

--- a/examples/resources/infoblox_cname_record.tf
+++ b/examples/resources/infoblox_cname_record.tf
@@ -1,18 +1,18 @@
 // CNAME-record, minimal set of parameters
 resource "infoblox_cname_record" "rec1" {
   canonical = "bla-bla-bla.somewhere.in.the.net"
-  alias = "hq-server.example1.org"
+  alias     = "hq-server.example1.org"
 }
 
 // CNAME-record, full set of parameters
 resource "infoblox_cname_record" "rec2" {
-  dns_view = "default.nondefault_netview"
+  dns_view  = "default.nondefault_netview"
   canonical = "strange-place.somewhere.in.the.net"
-  alias = "alarm-server.example3.org"
-  comment = "we need to keep an eye on this strange host"
-  ttl = 0 // disable caching
+  alias     = "alarm-server.example3.org"
+  comment   = "we need to keep an eye on this strange host"
+  ttl       = 0 // disable caching
   ext_attrs = jsonencode({
-    Site = "unknown"
+    Site     = "unknown"
     Location = "TBD"
   })
 }

--- a/examples/resources/infoblox_dns_view.tf
+++ b/examples/resources/infoblox_dns_view.tf
@@ -5,9 +5,9 @@ resource "infoblox_dns_view" "view1" {
 
 //creating DNS view resource with full set of parameters
 resource "infoblox_dns_view" "view2" {
-  name = "customview"
+  name         = "customview"
   network_view = "default"
-  comment = "test dns view example"
+  comment      = "test dns view example"
   ext_attrs = jsonencode({
     "Site" = "Main test site"
   })
@@ -15,9 +15,9 @@ resource "infoblox_dns_view" "view2" {
 
 // creating DNS View under non default network view
 resource "infoblox_dns_view" "view3" {
-  name = "custom_view"
+  name         = "custom_view"
   network_view = "non_defaultview"
-  comment = "example under custom network view"
+  comment      = "example under custom network view"
   ext_attrs = jsonencode({
     "Site" = "Cal Site"
   })

--- a/examples/resources/infoblox_ip_allocation.tf
+++ b/examples/resources/infoblox_ip_allocation.tf
@@ -2,17 +2,17 @@
 resource "infoblox_ip_allocation" "allocation1" {
   dns_view = "default" // this time the parameter is not optional, because...
   # enable_dns = true // ... this is 'true', by default
-  fqdn = "host1.example1.org" // this resource type is implemented as a host record on NIOS side
+  fqdn      = "host1.example1.org" // this resource type is implemented as a host record on NIOS side
   ipv4_addr = "1.2.3.4"
 }
 
 // Wide set of parameters
 resource "infoblox_ip_allocation" "allocation2" {
-  dns_view = "nondefault_dnsview1"
-  fqdn = "host2.example2.org"
+  dns_view  = "nondefault_dnsview1"
+  fqdn      = "host2.example2.org"
   ipv6_addr = "2002:1f93::1234"
-  ttl = 120
-  comment = "another host record, statically allocated"
+  ttl       = 120
+  comment   = "another host record, statically allocated"
   ext_attrs = jsonencode({
     "Tenant ID" = "tenant_3261798"
   })
@@ -20,13 +20,13 @@ resource "infoblox_ip_allocation" "allocation2" {
 
 // IPv4 and IPv6 at the same time
 resource "infoblox_ip_allocation" "allocation3" {
-  dns_view = "nondefault_dnsview2"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview" // we have to mention the exact network view which the DNS view belongs to
-  fqdn = "host3.example4.org"
-  ipv6_addr = "2002:1f93::12:40"
-  ipv4_addr = "1.2.3.40"
-  ttl = 0
-  comment = "still statically allocated, but IPv4 and IPv6 together"
+  fqdn         = "host3.example4.org"
+  ipv6_addr    = "2002:1f93::12:40"
+  ipv4_addr    = "1.2.3.40"
+  ttl          = 0
+  comment      = "still statically allocated, but IPv4 and IPv6 together"
   ext_attrs = jsonencode({
     "Tenant ID" = "tenant_3261798"
   })
@@ -35,9 +35,9 @@ resource "infoblox_ip_allocation" "allocation3" {
 resource "infoblox_ip_allocation" "allocation4" {
   enable_dns = false
   # dns_view = "nondefault_dnsview2" // dns_view makes no sense when enable_dns = false and
-                                     // you MUST remove it or comment out
+  // you MUST remove it or comment out
   network_view = "nondefault_netview" // we have to mention the exact network view which the DNS view belongs to
-  fqdn = "host4" // just one name component, because there is no host-to-DNS-zone assignment
+  fqdn         = "host4"              // just one name component, because there is no host-to-DNS-zone assignment
 
   // either of the IP addresses must belong to an existing
   // network (not a network container) in the GIVEN network view,
@@ -51,9 +51,9 @@ resource "infoblox_ip_allocation" "allocation4" {
 
 // dynamic allocation
 resource "infoblox_ip_allocation" "allocation5" {
-  dns_view = "nondefault_dnsview2"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview"
-  fqdn = "host5.example4.org"
-  ipv6_cidr = infoblox_ipv6_network.net2.cidr
-  ipv4_cidr = infoblox_ipv4_network.net2.cidr
+  fqdn         = "host5.example4.org"
+  ipv6_cidr    = infoblox_ipv6_network.net2.cidr
+  ipv4_cidr    = infoblox_ipv4_network.net2.cidr
 }

--- a/examples/resources/infoblox_ip_association.tf
+++ b/examples/resources/infoblox_ip_association.tf
@@ -18,7 +18,7 @@ resource "infoblox_ip_association" "association3" {
   enable_dhcp = true // all systems go
 
   mac_addr = "12:43:fd:ba:9c:c9"
-  duid = "00:43:d2:0a:11:e6"
+  duid     = "00:43:d2:0a:11:e6"
 }
 
 resource "infoblox_ip_association" "association4" {

--- a/examples/resources/infoblox_ipv4_network.tf
+++ b/examples/resources/infoblox_ipv4_network.tf
@@ -5,11 +5,11 @@ resource "infoblox_ipv4_network" "net1" {
 
 // full set of parameters for statically allocated IPv4 network
 resource "infoblox_ipv4_network" "net2" {
-  cidr = "10.1.0.0/24"
+  cidr         = "10.1.0.0/24"
   network_view = "nondefault_netview"
-  reserve_ip = 5
-  gateway = "10.1.0.254"
-  comment = "small network for testing"
+  reserve_ip   = 5
+  gateway      = "10.1.0.254"
+  comment      = "small network for testing"
   ext_attrs = jsonencode({
     "Site" = "bla-bla-bla... testing..."
   })
@@ -17,12 +17,12 @@ resource "infoblox_ipv4_network" "net2" {
 
 // full set of parameters for dynamically allocated IPv4 network
 resource "infoblox_ipv4_network" "net3" {
-  parent_cidr = infoblox_ipv4_network_container.nc1.cidr // reference to the resource from another example
-  allocate_prefix_len = 26 // 24 (existing network container) + 2 (new network), prefix
-  network_view = "default" // we may omit this but it is not a mistake to specify explicitly
-  reserve_ip = 2
-  gateway = "none" // no gateway defined for this network
-  comment = "even smaller network for testing"
+  parent_cidr         = infoblox_ipv4_network_container.nc1.cidr // reference to the resource from another example
+  allocate_prefix_len = 26                                       // 24 (existing network container) + 2 (new network), prefix
+  network_view        = "default"                                // we may omit this but it is not a mistake to specify explicitly
+  reserve_ip          = 2
+  gateway             = "none" // no gateway defined for this network
+  comment             = "even smaller network for testing"
   ext_attrs = jsonencode({
     "Site" = "any place you wish ..."
   })

--- a/examples/resources/infoblox_ipv4_network_container.tf
+++ b/examples/resources/infoblox_ipv4_network_container.tf
@@ -5,23 +5,23 @@ resource "infoblox_ipv4_network_container" "nc1" {
 
 // full set of parameters for statically allocated IPv4 network container
 resource "infoblox_ipv4_network_container" "nc2" {
-  cidr = "10.2.0.0/24" // we may allocate the same IP address range but in another network view
+  cidr         = "10.2.0.0/24" // we may allocate the same IP address range but in another network view
   network_view = "nondefault_netview"
-  comment = "one of our clients"
+  comment      = "one of our clients"
   ext_attrs = jsonencode({
-    "Site" = "remote office"
+    "Site"    = "remote office"
     "Country" = "Australia"
   })
 }
 
 // full set of parameters for dynamic allocation of network containers
 resource "infoblox_ipv4_network_container" "nc3" {
-  parent_cidr = infoblox_ipv4_network_container.nc2.cidr
+  parent_cidr         = infoblox_ipv4_network_container.nc2.cidr
   allocate_prefix_len = 26
-  network_view = "nondefault_netview"
-  comment = "one of our clients"
+  network_view        = "nondefault_netview"
+  comment             = "one of our clients"
   ext_attrs = jsonencode({
-    "Site" = "remote office"
+    "Site"    = "remote office"
     "Country" = "Australia"
   })
 }

--- a/examples/resources/infoblox_ipv6_network.tf
+++ b/examples/resources/infoblox_ipv6_network.tf
@@ -5,11 +5,11 @@ resource "infoblox_ipv6_network" "net1" {
 
 // full set of parameters for statically allocated IPv6 network
 resource "infoblox_ipv6_network" "net2" {
-  cidr = "2002:1f93:0:4::/96"
+  cidr         = "2002:1f93:0:4::/96"
   network_view = "nondefault_netview"
   reserve_ipv6 = 10
-  gateway = "2002:1f93:0:4::1"
-  comment = "let's try IPv6"
+  gateway      = "2002:1f93:0:4::1"
+  comment      = "let's try IPv6"
   ext_attrs = jsonencode({
     "Site" = "somewhere in Antarctica"
   })
@@ -17,12 +17,12 @@ resource "infoblox_ipv6_network" "net2" {
 
 // full set of parameters for dynamically allocated IPv6 network
 resource "infoblox_ipv6_network" "net3" {
-  parent_cidr = infoblox_ipv6_network_container.nc1.cidr // reference to the resource from another example
-  allocate_prefix_len = 100 // 96 (existing network container) + 4 (new network), prefix
-  network_view = "default" // we may omit this but it is not a mistake to specify explicitly
-  reserve_ipv6 = 20
-  gateway = "none" // no gateway defined for this network
-  comment = "the network for the Test Lab"
+  parent_cidr         = infoblox_ipv6_network_container.nc1.cidr // reference to the resource from another example
+  allocate_prefix_len = 100                                      // 96 (existing network container) + 4 (new network), prefix
+  network_view        = "default"                                // we may omit this but it is not a mistake to specify explicitly
+  reserve_ipv6        = 20
+  gateway             = "none" // no gateway defined for this network
+  comment             = "the network for the Test Lab"
   ext_attrs = jsonencode({
     "Site" = "small inner cluster"
   })

--- a/examples/resources/infoblox_ipv6_network_container.tf
+++ b/examples/resources/infoblox_ipv6_network_container.tf
@@ -5,23 +5,23 @@ resource "infoblox_ipv6_network_container" "nc1" {
 
 // full set of parameters for statically allocated IPv6 network container
 resource "infoblox_ipv6_network_container" "nc2" {
-  cidr = "2002:1f93:0:2::/96"
+  cidr         = "2002:1f93:0:2::/96"
   network_view = "nondefault_netview"
-  comment = "new generation network segment"
+  comment      = "new generation network segment"
   ext_attrs = jsonencode({
-    "Site" = "space station"
+    "Site"    = "space station"
     "Country" = "Earth orbit"
   })
 }
 
 // full set of parameters for dynamic allocation of network containers
 resource "infoblox_ipv6_network_container" "ncv6" {
-  parent_cidr = infoblox_ipv6_network_container.nc2.cidr
+  parent_cidr         = infoblox_ipv6_network_container.nc2.cidr
   allocate_prefix_len = 97
-  network_view = "default"
-  comment = "dynamic allocation of network container"
+  network_view        = "default"
+  comment             = "dynamic allocation of network container"
   ext_attrs = jsonencode({
     "Tenant ID" = "terraform_test_tenant"
-    Site = "Test site"
+    Site        = "Test site"
   })
 }

--- a/examples/resources/infoblox_mx_record.tf
+++ b/examples/resources/infoblox_mx_record.tf
@@ -1,18 +1,18 @@
 // MX-record, minimal set of parameters
 resource "infoblox_mx_record" "rec1" {
-  fqdn = "rec1.example.org"
+  fqdn           = "rec1.example.org"
   mail_exchanger = "sample.zone2.com"
-  preference = 30
+  preference     = 30
 }
 
 // MX-record, full set of parameters
 resource "infoblox_mx_record" "rec2" {
-  dns_view = "nondefault_dnsview1"
-  fqdn = "rec2.example2.org"
+  dns_view       = "nondefault_dnsview1"
+  fqdn           = "rec2.example2.org"
   mail_exchanger = "sample.test.com"
-  preference = 40
-  comment = "example MX-record"
-  ttl = 120
+  preference     = 40
+  comment        = "example MX-record"
+  ttl            = 120
   ext_attrs = jsonencode({
     "Location" = "Las Vegas"
   })

--- a/examples/resources/infoblox_network_view.tf
+++ b/examples/resources/infoblox_network_view.tf
@@ -1,5 +1,5 @@
 resource "infoblox_network_view" "netview1234" {
-  name = "one_more_network_view"
+  name    = "one_more_network_view"
   comment = "example network view"
   ext_attrs = jsonencode({
     "Location" = "the North pole"

--- a/examples/resources/infoblox_ptr_record.tf
+++ b/examples/resources/infoblox_ptr_record.tf
@@ -5,11 +5,11 @@
 //   2) 'record_name' - in the form of a domain name (ex. 1.0.0.10.in-addr.arpa)
 resource "infoblox_ptr_record" "rec1" {
   ptrdname = "rec1.example1.org"
-  ip_addr = "10.0.0.1"
+  ip_addr  = "10.0.0.1"
 }
 
 resource "infoblox_ptr_record" "rec2" {
-  ptrdname = "rec2.example1.org"
+  ptrdname    = "rec2.example1.org"
   record_name = "2.0.0.10.in-addr.arpa"
 }
 
@@ -17,9 +17,9 @@ resource "infoblox_ptr_record" "rec2" {
 resource "infoblox_ptr_record" "rec3" {
   ptrdname = "rec3.example2.org"
   dns_view = "nondefault_dnsview1"
-  ip_addr = "2002:1f93::3"
-  comment = "workstation #3"
-  ttl = 300 # 5 minutes
+  ip_addr  = "2002:1f93::3"
+  comment  = "workstation #3"
+  ttl      = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -28,17 +28,17 @@ resource "infoblox_ptr_record" "rec3" {
 // dynamically allocated PTR-record, minimal set of parameters
 resource "infoblox_ptr_record" "rec4" {
   ptrdname = "rec4.example2.org"
-  cidr = infoblox_ipv4_network.net1.cidr
+  cidr     = infoblox_ipv4_network.net1.cidr
 }
 
 // dynamically allocated PTR-record, full set of parameters, non-default network view
 resource "infoblox_ptr_record" "rec5" {
-  ptrdname = "rec5.example2.org"
-  dns_view = "nondefault_dnsview2"
+  ptrdname     = "rec5.example2.org"
+  dns_view     = "nondefault_dnsview2"
   network_view = "nondefault_netview"
-  cidr = infoblox_ipv4_network.net2.cidr
-  comment = "workstation #5"
-  ttl = 300 # 5 minutes
+  cidr         = infoblox_ipv4_network.net2.cidr
+  comment      = "workstation #5"
+  ttl          = 300 # 5 minutes
   ext_attrs = jsonencode({
     "Location" = "the main office"
   })
@@ -46,6 +46,6 @@ resource "infoblox_ptr_record" "rec5" {
 
 // PTR-record in a forward-mapping zone
 resource "infoblox_ptr_record" "rec6_forward" {
-  ptrdname = "example1.org"
+  ptrdname    = "example1.org"
   record_name = "www.example1.org"
 }

--- a/examples/resources/infoblox_srv_record.tf
+++ b/examples/resources/infoblox_srv_record.tf
@@ -1,23 +1,23 @@
 // minimal set of parameters
 resource "infoblox_srv_record" "rec1" {
-    name = "_http._tcp.example.org"
-    priority = 100
-    weight = 75
-    port = 8080
-    target = "www.example.org"
-} 
+  name     = "_http._tcp.example.org"
+  priority = 100
+  weight   = 75
+  port     = 8080
+  target   = "www.example.org"
+}
 
 // all set of parameters for SRV record
 resource "infoblox_srv_record" "rec2" {
-    dns_view = "nondefault_dnsview1"
-    name = "_sip._udp.example2.org"
-    priority = 12
-    weight = 10
-    port = 5060
-    target = "sip.example2.org"
-    ttl = 3600
-    comment = "example SRV record"
-    ext_attrs = jsonencode({
-        "Location" = "65.8665701230204, -37.00791763398113"
-    })
+  dns_view = "nondefault_dnsview1"
+  name     = "_sip._udp.example2.org"
+  priority = 12
+  weight   = 10
+  port     = 5060
+  target   = "sip.example2.org"
+  ttl      = 3600
+  comment  = "example SRV record"
+  ext_attrs = jsonencode({
+    "Location" = "65.8665701230204, -37.00791763398113"
+  })
 }

--- a/examples/resources/infoblox_txt_record.tf
+++ b/examples/resources/infoblox_txt_record.tf
@@ -7,18 +7,18 @@ resource "infoblox_txt_record" "rec1" {
 // some parameters for a TXT-Record
 resource "infoblox_txt_record" "rec2" {
   dns_view = "default" // may be omitted
-  fqdn = "sample2.example.org"
-  text = "\"data for TXT-record #2\""
-  ttl = 120 // 120s
+  fqdn     = "sample2.example.org"
+  text     = "\"data for TXT-record #2\""
+  ttl      = 120 // 120s
 }
 
 // all the parameters for a TXT-Record
 resource "infoblox_txt_record" "rec3" {
   dns_view = "nondefault_dnsview1"
-  fqdn = "example3.example2.org"
-  text = "\"data for TXT-record #3\""
-  ttl = 300
-  comment = "example TXT record #3"
+  fqdn     = "example3.example2.org"
+  text     = "\"data for TXT-record #3\""
+  ttl      = 300
+  comment  = "example TXT record #3"
   ext_attrs = jsonencode({
     "Location" = "65.8665701230204, -37.00791763398113"
   })

--- a/examples/resources/infoblox_zone_auth.tf
+++ b/examples/resources/infoblox_zone_auth.tf
@@ -1,16 +1,16 @@
 //forward mapping zone, with full set of parameters
 resource "infoblox_zone_auth" "zone1" {
-  fqdn = "test3.com"
-  view = "default"
-  zone_format = "FORWARD"
-  ns_group = ""
+  fqdn              = "test3.com"
+  view              = "default"
+  zone_format       = "FORWARD"
+  ns_group          = ""
   restart_if_needed = true
-  soa_default_ttl = 36000
-  soa_expire = 72000
-  soa_negative_ttl = 600
-  soa_refresh = 1800
-  soa_retry = 900
-  comment = "Zone Auth created newly"
+  soa_default_ttl   = 36000
+  soa_expire        = 72000
+  soa_negative_ttl  = 600
+  soa_refresh       = 1800
+  soa_retry         = 900
+  comment           = "Zone Auth created newly"
   ext_attrs = jsonencode({
     Location = "AcceptanceTerraform"
   })
@@ -18,17 +18,17 @@ resource "infoblox_zone_auth" "zone1" {
 
 //IPV4 reverse mapping zone, with full set of parameters
 resource "infoblox_zone_auth" "zone2" {
-  fqdn = "10.0.0.0/24"
-  view = "default"
-  zone_format = "IPV4"
-  ns_group = "nsgroup1"
+  fqdn              = "10.0.0.0/24"
+  view              = "default"
+  zone_format       = "IPV4"
+  ns_group          = "nsgroup1"
   restart_if_needed = true
-  soa_default_ttl = 37000
-  soa_expire = 92000
-  soa_negative_ttl = 900
-  soa_refresh = 2100
-  soa_retry = 800
-  comment = "IPV4 reverse zone auth created"
+  soa_default_ttl   = 37000
+  soa_expire        = 92000
+  soa_negative_ttl  = 900
+  soa_refresh       = 2100
+  soa_retry         = 800
+  comment           = "IPV4 reverse zone auth created"
   ext_attrs = jsonencode({
     Location = "TestTerraform"
   })
@@ -36,11 +36,11 @@ resource "infoblox_zone_auth" "zone2" {
 
 //IPV6 reverse mapping zone, with minimal set of parameters
 resource "infoblox_zone_auth" "zone3" {
-  fqdn = "2002:1100::/64"
-  view = "non_defaultview"
+  fqdn        = "2002:1100::/64"
+  view        = "non_defaultview"
   zone_format = "IPV6"
-  ns_group = "nsgroup2"
-  comment = "IPV6 reverse zone auth created"
+  ns_group    = "nsgroup2"
+  comment     = "IPV6 reverse zone auth created"
   ext_attrs = jsonencode({
     Location = "Random TF location"
   })

--- a/examples/resources/infoblox_zone_forward.tf
+++ b/examples/resources/infoblox_zone_forward.tf
@@ -2,40 +2,40 @@
 resource "infoblox_zone_forward" "forward_zone_forwardTo" {
   fqdn = "min_params.ex.org"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
 }
 
 //forward zone with full set of parameters
 resource "infoblox_zone_forward" "forward_zone_full_parameters" {
-  fqdn = "max_params.ex.org"
-  view = "nondefault_view"
+  fqdn        = "max_params.ex.org"
+  view        = "nondefault_view"
   zone_format = "FORWARD"
-  comment = "test sample forward zone"
+  comment     = "test sample forward zone"
   forward_to {
-    name = "te32.dz.ex.com"
+    name    = "te32.dz.ex.com"
     address = "10.0.0.1"
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_216"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_216"
+    forwarders_only         = true
     use_override_forwarders = false
     forward_to {
-      name = "cc.fwd.com"
+      name    = "cc.fwd.com"
       address = "10.1.1.1"
     }
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_0"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_0"
+    forwarders_only         = true
     use_override_forwarders = true
     forward_to {
-      name = "kk.fwd.com"
+      name    = "kk.fwd.com"
       address = "10.2.1.31"
     }
   }
@@ -43,8 +43,8 @@ resource "infoblox_zone_forward" "forward_zone_full_parameters" {
 
 //forward zone with ns_group and external_ns_group
 resource "infoblox_zone_forward" "forward_zone_nsGroup_externalNsGroup" {
-  fqdn = "params_ns_ens.ex.org"
-  ns_group = "test"
+  fqdn              = "params_ns_ens.ex.org"
+  ns_group          = "test"
   external_ns_group = "stub server"
 }
 
@@ -52,19 +52,19 @@ resource "infoblox_zone_forward" "forward_zone_nsGroup_externalNsGroup" {
 resource "infoblox_zone_forward" "forward_zone_forwardTo_forwardingServers" {
   fqdn = "params_fs_ft.ex.org"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_0"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_0"
+    forwarders_only         = true
     use_override_forwarders = true
     forward_to {
-      name = "kk.fwd.com"
+      name    = "kk.fwd.com"
       address = "10.2.1.31"
     }
   }
@@ -72,32 +72,32 @@ resource "infoblox_zone_forward" "forward_zone_forwardTo_forwardingServers" {
 
 //forward zone IPV4 reverse mapping zone
 resource "infoblox_zone_forward" "forward_zone_IPV4_nsGroup_externalNsGroup_comment" {
-  fqdn = "192.1.0.0/24"
-  comment = "Forward zone IPV4"
+  fqdn              = "192.1.0.0/24"
+  comment           = "Forward zone IPV4"
   external_ns_group = "stub server"
-  zone_format = "IPV4"
-  ns_group = "test"
+  zone_format       = "IPV4"
+  ns_group          = "test"
 }
 
 //forward zone IPV6 reverse mapping zone
 resource "infoblox_zone_forward" "forward_zone_IPV6_forwardTo_forwardingServers" {
-  fqdn = "3001:db8::/64"
-  comment = "Forward zone IPV6"
+  fqdn        = "3001:db8::/64"
+  comment     = "Forward zone IPV6"
   zone_format = "IPV6"
   forward_to {
-    name = "test22.dz.ex.com"
+    name    = "test22.dz.ex.com"
     address = "10.0.0.1"
   }
   forward_to {
-    name = "test2.dz.ex.com"
+    name    = "test2.dz.ex.com"
     address = "10.0.0.2"
   }
   forwarding_servers {
-    name = "infoblox.172_28_83_0"
-    forwarders_only = true
+    name                    = "infoblox.172_28_83_0"
+    forwarders_only         = true
     use_override_forwarders = true
     forward_to {
-      name = "kk.fwd.com"
+      name    = "kk.fwd.com"
       address = "10.2.1.31"
     }
   }

--- a/vendor/google.golang.org/grpc/README.md
+++ b/vendor/google.golang.org/grpc/README.md
@@ -17,13 +17,12 @@ RPC framework that puts mobile and HTTP/2 first. For more information see the
 Simply add the following import to your code, and then `go [build|run|test]`
 will automatically fetch the necessary dependencies:
 
-
 ```go
 import "google.golang.org/grpc"
 ```
 
 > **Note:** If you are trying to access `grpc-go` from **China**, see the
-> [FAQ](#FAQ) below.
+> [FAQ](#faq) below.
 
 ## Learn more
 
@@ -74,14 +73,15 @@ The default logger is controlled by environment variables. Turn everything on
 like this:
 
 ```console
-$ export GRPC_GO_LOG_VERBOSITY_LEVEL=99
-$ export GRPC_GO_LOG_SEVERITY_LEVEL=info
+export GRPC_GO_LOG_VERBOSITY_LEVEL=99
+export GRPC_GO_LOG_SEVERITY_LEVEL=info
 ```
 
 ### The RPC failed with error `"code = Unavailable desc = transport is closing"`
 
 This error means the connection the RPC is using was closed, and there are many
 possible reasons, including:
+
  1. mis-configured transport credentials, connection failed on handshaking
  1. bytes disrupted, possibly by a proxy in between
  1. server shutdown
@@ -94,12 +94,11 @@ possible reasons, including:
 
 It can be tricky to debug this because the error happens on the client side but
 the root cause of the connection being closed is on the server side. Turn on
-logging on __both client and server__, and see if there are any transport
+logging on **both client and server**, and see if there are any transport
 errors.
 
 [API]: https://pkg.go.dev/google.golang.org/grpc
 [Go]: https://golang.org
-[Go module]: https://github.com/golang/go/wiki/Modules
 [gRPC]: https://grpc.io
 [Go gRPC docs]: https://grpc.io/docs/languages/go
 [Performance benchmark]: https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5180705743044608


### PR DESCRIPTION
Apply some general formatting rules for Markdown.

Additionally format all code-snippets in the documentation with `terraform fmt`/`tofu fmt` to improve general readability.