### PR TITLE
Fix for Npa 193- Failed to update host record: Invalid view value caused by trailing whitespace when enabling DNS

### DIFF
--- a/infoblox/resource_infoblox_ip_allocation.go
+++ b/infoblox/resource_infoblox_ip_allocation.go
@@ -489,6 +489,7 @@ func resourceAllocationUpdate(d *schema.ResourceData, m interface{}) (err error)
 
 	enableDNS := d.Get("enable_dns").(bool)
 	dnsView := d.Get("dns_view").(string)
+	dnsView = strings.TrimSpace(dnsView)
 	fqdn := d.Get("fqdn").(string)
 	if d.HasChange("dns_view") && !d.HasChange("enable_dns") {
 		return fmt.Errorf(


### PR DESCRIPTION
Fix for Npa 193

Failed to update host record: Invalid view value caused by trailing whitespace when enabling DNS