### PR TITLE
datasource_network_utilization and import of a/ptr records 

### DIFF
--- a/docs/data-sources/infoblox_ipv4_network.md
+++ b/docs/data-sources/infoblox_ipv4_network.md
@@ -6,6 +6,7 @@ The data source for the network object allows you to get the following parameter
 * `cidr`: the network block which corresponds to the network, in CIDR notation. Example: `192.0.17.0/24`
 * `comment`: a description of the network. This is a regular comment. Example: `Untrusted network`.
 * `ext_attrs`: The set of extensible attributes, if any. The content is formatted as string of JSON map. Example: `"{\"Owner\":\"State Library\",\"Administrator\":\"unknown\"}"`.
+* `gateway`: the gateway IP defined in network options (routers'). Example: `192.0.17.1`
 
 
 For usage of filters, add the fields as keys and appropriate values to be passed to the keys like `name`, `view` corresponding to object.

--- a/docs/data-sources/infoblox_ipv4_network.md
+++ b/docs/data-sources/infoblox_ipv4_network.md
@@ -7,7 +7,7 @@ The data source for the network object allows you to get the following parameter
 * `comment`: a description of the network. This is a regular comment. Example: `Untrusted network`.
 * `ext_attrs`: The set of extensible attributes, if any. The content is formatted as string of JSON map. Example: `"{\"Owner\":\"State Library\",\"Administrator\":\"unknown\"}"`.
 * `gateway`: the gateway IP defined in network options (routers'). Example: `192.0.17.1`
-
+* `utilization`: The network utilization in percentage * 10. Example: `500` for `50%` of network utilization
 
 For usage of filters, add the fields as keys and appropriate values to be passed to the keys like `name`, `view` corresponding to object.
 From the below list of supported arguments for filters,  use only the searchable fields for retriving the matching records.

--- a/docs/data-sources/infoblox_ipv6_network.md
+++ b/docs/data-sources/infoblox_ipv6_network.md
@@ -6,7 +6,8 @@ The data source for the network object allows you to get the following parameter
 * `cidr`: the network block which corresponds to the network, in CIDR notation. Example: `2002:1f93:0:4::/96`
 * `comment`: a description of the network. This is a regular comment. Example: `Untrusted network`.
 * `ext_attrs`: The set of extensible attributes, if any. The content is formatted as string of JSON map. Example: `"{\"Owner\":\"State Library\",\"Administrator\":\"unknown\"}"`.
-
+* `gateway`: the gateway IP defined in network options (routers'). Example: `192.0.17.1`
+* `utilization`: The network utilization in percentage * 10. Example: `500` for `50%` of network utilization
 
 To retrieve information about IPv6 network that match the specified filters, use the `filters` argument and specify the parameters mentioned in the below table. These are the searchable parameters of the corresponding object in Infoblox NIOS WAPI. If you do not specify any parameter, the data source retrieves information about all host records in the NIOS Grid.
 

--- a/infoblox/datasource_infoblox_network.go
+++ b/infoblox/datasource_infoblox_network.go
@@ -49,6 +49,16 @@ func dataSourceNetwork() *schema.Resource {
 							Computed:    true,
 							Description: "The Extensible attributes for network datasource, as a map in JSON format",
 						},
+						"gateway": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The Gateway IP Address (identified using Options routers)",
+						},
+						"utilization": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The network utilization in percentage",
+						},
 					},
 				},
 			},
@@ -63,6 +73,8 @@ func dataSourceIPv4NetworkRead(ctx context.Context, d *schema.ResourceData, m in
 
 	n := &ibclient.Ipv4Network{}
 	n.SetReturnFields(append(n.ReturnFields(), "extattrs"))
+	n.SetReturnFields(append(n.ReturnFields(), "options"))
+	n.SetReturnFields(append(n.ReturnFields(), "utilization"))
 
 	filters := filterFromMap(d.Get("filters").(map[string]interface{}))
 	qp := ibclient.NewQueryParams(false, filters)
@@ -124,6 +136,19 @@ func flattenIpv4Network(network ibclient.Ipv4Network) (map[string]interface{}, e
 	if network.Comment != nil {
 		res["comment"] = *network.Comment
 	}
+	
+	if network.Utilization  != 0 {
+		res["utilization"] = fmt.Sprintf("%d", network.Utilization)
+	}
+
+	if network.Options != nil {
+		for _, opt := range network.Options {
+			if opt.Name == "routers" {
+				res["gateway"] = opt.Value
+				break
+			}
+		}
+	}
 
 	return res, nil
 }
@@ -154,6 +179,19 @@ func flattenIpv6Network(network ibclient.Ipv6Network) (map[string]interface{}, e
 		res["comment"] = *network.Comment
 	}
 
+	if network.Utilization  != 0 {
+		res["utilization"] = fmt.Sprintf("%d", &network.Utilization)
+	}
+
+	if network.Options != nil {
+		for _, opt := range network.Options {
+			if opt.Name == "routers" {
+				res["gateway"] = opt.Value
+				break
+			}
+		}
+	}
+
 	return res, nil
 }
 
@@ -164,6 +202,8 @@ func dataSourceIPv6NetworkRead(ctx context.Context, d *schema.ResourceData, m in
 
 	n := &ibclient.Ipv6Network{}
 	n.SetReturnFields(append(n.ReturnFields(), "extattrs"))
+	n.SetReturnFields(append(n.ReturnFields(), "options"))
+	n.SetReturnFields(append(n.ReturnFields(), "utilization"))
 
 	filters := filterFromMap(d.Get("filters").(map[string]interface{}))
 	qp := ibclient.NewQueryParams(false, filters)

--- a/infoblox/resource_infoblox_a_record.go
+++ b/infoblox/resource_infoblox_a_record.go
@@ -218,8 +218,8 @@ func resourceARecordGet(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	connector := m.(ibclient.IBConnector)
-	objMgr := ibclient.NewObjectManager(connector, "Terraform", "")
+	// connector := m.(ibclient.IBConnector)
+	// objMgr := ibclient.NewObjectManager(connector, "Terraform", "")
 
 	// Get by Ref, if not found, then by Terraform Internal ID from EA
 	rec, err := searchObjectByRefOrInternalId("A", d, m)
@@ -278,17 +278,17 @@ func resourceARecordGet(d *schema.ResourceData, m interface{}) error {
 	if err = d.Set("ref", recA.Ref); err != nil {
 		return err
 	}
-	if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
-		dnsView, err := objMgr.GetDNSView(recA.View)
-		if err != nil {
-			return fmt.Errorf(
-				"error while retrieving information about DNS view '%s': %w",
-				recA.View, err)
-		}
-		if err = d.Set("network_view", dnsView.NetworkView); err != nil {
-			return err
-		}
-	}
+	// if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
+	// 	dnsView, err := objMgr.GetDNSView(recA.View)
+	// 	if err != nil {
+	// 		return fmt.Errorf(
+	// 			"error while retrieving information about DNS view '%s': %w",
+	// 			recA.View, err)
+	// 	}
+	// 	if err = d.Set("network_view", dnsView.NetworkView); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	if err = d.Set("fqdn", recA.Name); err != nil {
 		return err
@@ -552,17 +552,17 @@ func resourceARecordImport(d *schema.ResourceData, m interface{}) ([]*schema.Res
 	if err = d.Set("dns_view", obj.View); err != nil {
 		return nil, err
 	}
-	if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
-		dnsView, err := objMgr.GetDNSView(obj.View)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"error while retrieving information about DNS view '%s': %w",
-				obj.View, err)
-		}
-		if err = d.Set("network_view", dnsView.NetworkView); err != nil {
-			return nil, err
-		}
-	}
+	// if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
+	// 	dnsView, err := objMgr.GetDNSView(obj.View)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf(
+	// 			"error while retrieving information about DNS view '%s': %w",
+	// 			obj.View, err)
+	// 	}
+	// 	if err = d.Set("network_view", dnsView.NetworkView); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
 
 	if err = d.Set("fqdn", obj.Name); err != nil {
 		return nil, err

--- a/infoblox/resource_infoblox_ptr_record.go
+++ b/infoblox/resource_infoblox_ptr_record.go
@@ -253,13 +253,13 @@ func resourcePTRRecordGet(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	var tenantID string
-	if tempVal, ok := extAttrs[eaNameForTenantId]; ok {
-		tenantID = tempVal.(string)
-	}
+	// var tenantID string
+	// if tempVal, ok := extAttrs[eaNameForTenantId]; ok {
+	// 	tenantID = tempVal.(string)
+	// }
 
-	connector := m.(ibclient.IBConnector)
-	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+	// connector := m.(ibclient.IBConnector)
+	// objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 
 	rec, err := searchObjectByRefOrInternalId("PTR", d, m)
 	if err != nil {
@@ -315,17 +315,17 @@ func resourcePTRRecordGet(d *schema.ResourceData, m interface{}) error {
 	if err = d.Set("ref", obj.Ref); err != nil {
 		return err
 	}
-	if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
-		dnsView, err := objMgr.GetDNSView(obj.View)
-		if err != nil {
-			return fmt.Errorf(
-				"error while retrieving information about DNS view '%s': %s",
-				obj.View, err)
-		}
-		if err = d.Set("network_view", dnsView.NetworkView); err != nil {
-			return err
-		}
-	}
+	// if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
+	// 	dnsView, err := objMgr.GetDNSView(obj.View)
+	// 	if err != nil {
+	// 		return fmt.Errorf(
+	// 			"error while retrieving information about DNS view '%s': %s",
+	// 			obj.View, err)
+	// 	}
+	// 	if err = d.Set("network_view", dnsView.NetworkView); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	if err = d.Set("ptrdname", obj.PtrdName); err != nil {
 		return err
@@ -654,17 +654,17 @@ func resourcePTRRecordImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	if err = d.Set("dns_view", obj.View); err != nil {
 		return nil, err
 	}
-	if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
-		dnsView, err := objMgr.GetDNSView(obj.View)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"error while retrieving information about DNS view '%s': %s",
-				obj.View, err)
-		}
-		if err = d.Set("network_view", dnsView.NetworkView); err != nil {
-			return nil, err
-		}
-	}
+	// if val, ok := d.GetOk("network_view"); !ok || val.(string) == "" {
+	// 	dnsView, err := objMgr.GetDNSView(obj.View)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf(
+	// 			"error while retrieving information about DNS view '%s': %s",
+	// 			obj.View, err)
+	// 	}
+	// 	if err = d.Set("network_view", dnsView.NetworkView); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
 
 	if err = d.Set("ptrdname", obj.PtrdName); err != nil {
 		return nil, err

--- a/vendor/github.com/infobloxopen/infoblox-go-client/v2/objects_generated.go
+++ b/vendor/github.com/infobloxopen/infoblox-go-client/v2/objects_generated.go
@@ -8054,6 +8054,9 @@ type Ipv6Network struct {
 
 	// The list of zones associated with this network.
 	ZoneAssociations []*Zoneassociation `json:"zone_associations,omitempty"`
+
+    // The network utilization in percentage.
+    Utilization uint32 `json:"utilization,omitempty"`
 }
 
 func (Ipv6Network) ObjectType() string {


### PR DESCRIPTION
This pull request is dedicated to retrieving 'utilization,' which represents the network utilization as a percentage, and it includes 'Add Gateway to Datasource ipv4_network and ipv6_network #426' by @chpag — what my company needs.