### PR TITLE
NPA-304, 305 Fix

### DIFF
--- a/infoblox/datasource_infoblox_dtc_lbdn.go
+++ b/infoblox/datasource_infoblox_dtc_lbdn.go
@@ -83,7 +83,7 @@ func dataSourceDtcLbdnRecord() *schema.Resource {
 						"pools": {
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: "Collection of load balanced servers",
+							Description: "Pools associated with an LBDN are collections of load-balanced servers",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"pool": {

--- a/infoblox/datasource_infoblox_dtc_lbdn.go
+++ b/infoblox/datasource_infoblox_dtc_lbdn.go
@@ -83,7 +83,7 @@ func dataSourceDtcLbdnRecord() *schema.Resource {
 						"pools": {
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: "The maximum time, in seconds, for which client specific LBDN responses will be cached. Zero specifies no caching.",
+							Description: "Collection of load balanced servers",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"pool": {

--- a/infoblox/datasource_infoblox_dtc_pool.go
+++ b/infoblox/datasource_infoblox_dtc_pool.go
@@ -271,12 +271,16 @@ func flattenDtcPool(pool ibclient.DtcPool, connector ibclient.IBConnector) (map[
 		res["lb_alternate_method"] = pool.LbAlternateMethod
 	}
 	if pool.LbAlternateTopology != nil {
+<<<<<<< HEAD
 		var topology ibclient.DtcTopology
 		err := connector.GetObject(&ibclient.DtcTopology{}, *pool.LbAlternateTopology, nil, &topology)
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s DtcTopology object: %s", *pool.LbAlternateTopology, err)
 		}
 		res["lb_alternate_topology"] = topology.Name
+=======
+		res["lb_alternate_topology"] = *pool.LbAlternateTopology
+>>>>>>> 27572b0 (implementation of DTC LBDN resource and datasource and DTC Pool datasource)
 	}
 	if pool.LbDynamicRatioAlternate != nil && pool.LbAlternateMethod == "DYNAMIC_RATIO" {
 		lbDynamicRatioAlternate, err := serializeSettingDynamicRatio(pool.LbDynamicRatioAlternate, connector)

--- a/infoblox/datasource_infoblox_dtc_pool.go
+++ b/infoblox/datasource_infoblox_dtc_pool.go
@@ -271,16 +271,12 @@ func flattenDtcPool(pool ibclient.DtcPool, connector ibclient.IBConnector) (map[
 		res["lb_alternate_method"] = pool.LbAlternateMethod
 	}
 	if pool.LbAlternateTopology != nil {
-<<<<<<< HEAD
 		var topology ibclient.DtcTopology
 		err := connector.GetObject(&ibclient.DtcTopology{}, *pool.LbAlternateTopology, nil, &topology)
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s DtcTopology object: %s", *pool.LbAlternateTopology, err)
 		}
 		res["lb_alternate_topology"] = topology.Name
-=======
-		res["lb_alternate_topology"] = *pool.LbAlternateTopology
->>>>>>> 27572b0 (implementation of DTC LBDN resource and datasource and DTC Pool datasource)
 	}
 	if pool.LbDynamicRatioAlternate != nil && pool.LbAlternateMethod == "DYNAMIC_RATIO" {
 		lbDynamicRatioAlternate, err := serializeSettingDynamicRatio(pool.LbDynamicRatioAlternate, connector)

--- a/infoblox/resource_infoblox_dtc_lbdn.go
+++ b/infoblox/resource_infoblox_dtc_lbdn.go
@@ -90,7 +90,7 @@ func resourceDtcLbdnRecord() *schema.Resource {
 			"pools": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "The maximum time, in seconds, for which client specific LBDN responses will be cached. Zero specifies no caching.",
+				Description: "Collection of load balanced servers",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pool": {
@@ -569,7 +569,7 @@ func resourceDtcLbdnUpdate(d *schema.ResourceData, m interface{}) error {
 
 	lbdn, err = objMgr.UpdateDtcLbdn(d.Id(), name, authZoneList, comment, disable, autoConsolidatedMonitors, newExtAttrs, lbMethod, patternsList, persistence, pools, priority, topology, typesList, ttl, useTtl)
 	if err != nil {
-		return fmt.Errorf("failed to update DTC LBDN with %s, ", err.Error())
+		return fmt.Errorf("failed to update DTC LBDN: %s.", err.Error())
 	}
 
 	updateSuccessful = true

--- a/infoblox/resource_infoblox_dtc_lbdn.go
+++ b/infoblox/resource_infoblox_dtc_lbdn.go
@@ -90,7 +90,7 @@ func resourceDtcLbdnRecord() *schema.Resource {
 			"pools": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Collection of load balanced servers",
+				Description: "Pools associated with the LBDN are collections of load-balanced servers",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pool": {

--- a/infoblox/resource_infoblox_dtc_pool.go
+++ b/infoblox/resource_infoblox_dtc_pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+	"reflect"
 )
 
 func addDefaultValues(input string) (string, error) {
@@ -194,8 +195,23 @@ func resourceDtcPool() *schema.Resource {
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					autoConsolidated, ok := d.GetOk("auto_consolidated_monitors")
-					if ok && autoConsolidated.(bool) {
-						return true // Suppress differences when auto_consolidated_monitors is true
+					oldVal, newVal := d.GetChange("consolidated_monitors")
+					oldValSlice, oldOk := oldVal.([]interface{})
+					newValSlice, newOk := newVal.([]interface{})
+					if autoConsolidated.(bool) {
+						// Suppress the diff for consolidated_monitors
+						if ok && autoConsolidated.(bool) {
+							//if oldOk && newOk && len(oldValSlice) != 0 && len(newValSlice) == 0 {
+							if oldOk && newOk {
+								if reflect.DeepEqual(oldValSlice, newValSlice) {
+									return true
+								}
+							}
+						}
+					} else {
+						if oldOk && !newOk {
+							return false
+						}
 					}
 					return false
 				},
@@ -374,6 +390,10 @@ func resourceDtcPoolCreate(d *schema.ResourceData, m interface{}) error {
 	}
 	lbAlternateMethod := d.Get("lb_alternate_method").(string)
 	autoConsolidatedMonitors := d.Get("auto_consolidated_monitors").(bool)
+	//consolidatedMonitors := d.Get("consolidated_monitors").([]interface{})
+	if autoConsolidatedMonitors && d.Get("consolidated_monitors") == "" {
+		return fmt.Errorf("consolidated_monitors must be empty when auto_consolidated_monitors is enabled")
+	}
 	disable := d.Get("disable").(bool)
 	availability := d.Get("availability").(string)
 	lbAlternateTopologyValue := d.Get("lb_alternate_topology").(string)
@@ -449,6 +469,14 @@ func resourceDtcPoolGet(d *schema.ResourceData, m interface{}) error {
 	}
 	if !*dtcPool.UseTtl {
 		ttl = ttlUndef
+	}
+	if err = d.Set("availability", dtcPool.Availability); err != nil {
+		return err
+	}
+	if dtcPool.Quorum != nil {
+		if err = d.Set("quorum", *dtcPool.Quorum); err != nil {
+			return err
+		}
 	}
 	if err = d.Set("ttl", ttl); err != nil {
 		return err
@@ -619,6 +647,11 @@ func resourceDtcPoolUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 	lbAlternateMethod := d.Get("lb_alternate_method").(string)
 	autoConsolidatedMonitors := d.Get("auto_consolidated_monitors").(bool)
+	_, ok := d.GetOk("consolidated_monitors")
+	// if autoConsolidatedMonitors is True and consolidated_monitors is given in tf file, then return an error
+	if autoConsolidatedMonitors && ok && d.HasChange("consolidated_monitors") {
+		return fmt.Errorf("either consolidated_monitors or auto_consolidated_monitors should be set")
+	}
 	disable := d.Get("disable").(bool)
 	availability := d.Get("availability").(string)
 	lbAlternateTopologyValue := d.Get("lb_alternate_topology").(string)
@@ -685,6 +718,18 @@ func resourceDtcPoolUpdate(d *schema.ResourceData, m interface{}) error {
 	newExtAttrs, err = mergeEAs(dtcPool.Ea, newExtAttrs, oldExtAttrs, connector)
 	if err != nil {
 		return err
+	}
+	// to unset consolidated_monitors, pass empty slice
+	_, isCmPresent := d.GetOk("consolidated_monitors")
+	if !isCmPresent && d.HasChange("consolidated_monitors") {
+		consolidatedMonitors = make([]map[string]interface{}, 0)
+	}
+	// if auto_consolidated_monitors is set and dtcPool has previous data for consolidated_monitors, then set consolidated_monitors to nil
+	if autoConsolidatedMonitors && dtcPool.ConsolidatedMonitors != nil {
+		consolidatedMonitors = nil
+	}
+	if !autoConsolidatedMonitors && d.Get("consolidated_monitors") == "" {
+		consolidatedMonitors = nil
 	}
 	dtcPool, err = objMgr.UpdateDtcPool(d.Id(), comment, name, lbPreferredMethod, lbDynamicRatioPreferred, servers, monitors, lbPreferredTopology, lbAlternateMethod, lbAlternateTopology, lbDynamicRatioAlternate, newExtAttrs, autoConsolidatedMonitors, availability, consolidatedMonitors, ttl, useTtl, disable, quorum)
 	if err != nil {
@@ -790,6 +835,14 @@ func resourceDtcPoolImport(d *schema.ResourceData, m interface{}) ([]*schema.Res
 		}
 	}
 
+	if err = d.Set("availability", obj.Availability); err != nil {
+		return nil, err
+	}
+	if obj.Quorum != nil {
+		if err = d.Set("quorum", *obj.Quorum); err != nil {
+			return nil, err
+		}
+	}
 	if err = d.Set("ttl", ttl); err != nil {
 		return nil, err
 	}

--- a/infoblox/resource_infoblox_dtc_pool_test.go
+++ b/infoblox/resource_infoblox_dtc_pool_test.go
@@ -179,8 +179,8 @@ func testAccDtcPoolCompare(
 	}
 }
 
-var regexMissingLbDynamicRatioPreferred = regexp.MustCompile("lbDynamicRatioPreferred cannot be nil when lbPreferredMethod is set to DYNAMIC_RATIO")
-var regexMissingLbPreferredTopology = regexp.MustCompile("lbPreferredTopology cannot be nil when lbPreferredMethod is set to TOPOLOGY")
+var regexMissingLbDynamicRatioPreferred = regexp.MustCompile("LbDynamicRatioPreferred cannot be nil when the preferred load balancing method is set to DYNAMIC_RATIO")
+var regexMissingLbPreferredTopology = regexp.MustCompile("preferred topology cannot be nil when preferred load balancing method is set to TOPOLOGY")
 
 func TestAccResourceDtcPool(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
1. NPA-304 Fix: Adding 'availability' and 'quorum' fields in Import and Get function in DTC pool resource
2. NPA-305 Fix: 

- Handling DiffSuppressFunc for consolidated_monitors field when auto_consolidated_monitors and consolidated_monitors fields given and data to be passed to UpdateDtcPool function.