### PR TITLE
Add VLAN resource support with enhancements and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### VLAN Resource Improvements
+- Added required `parent` field to specify the VLAN View or VLAN Range for the VLAN
+- Made `vlan_id` optional - when not specified, the next available VLAN ID is automatically allocated from the parent range using `func:nextavailablevlanid`
+- Fixed read/update/delete operations that were failing due to unsupported object type in `searchObjectByRefOrInternalId`
+- Fixed JSON unmarshaling error for `parent` field (API returns object but Go client expects string)
+- Updated documentation with examples for both explicit and auto-allocated VLAN IDs
+
 ## [v2.11.0](https://github.com/infobloxopen/terraform-provider-infoblox/tree/v2.11.0) (2025-10-20)
 
 - Improved error handling in data sources by treating "not found" responses as valid empty results, enhancing stability.

--- a/docs/resources/infoblox_vlan.md
+++ b/docs/resources/infoblox_vlan.md
@@ -1,0 +1,96 @@
+# VLAN
+
+The `infoblox_vlan` resource enables you to perform `create`, `read`, `update`, and `delete` operations on VLANs in a NIOS appliance.
+The resource represents the 'vlan' WAPI object in NIOS.
+
+The following list describes the parameters you can define in the `infoblox_vlan` resource block:
+
+* `parent`: required, specifies the VLAN View or VLAN Range to which this VLAN belongs (reference string). This field cannot be changed after creation.
+* `name`: required, specifies the name of the VLAN.
+* `vlan_id`: optional, specifies the VLAN ID value (typically 1-4094). If not specified, the next available VLAN ID will be automatically allocated from the parent range.
+* `comment`: optional, describes the VLAN with a descriptive comment.
+* `description`: optional, provides a description for the VLAN object, may be potentially used for longer VLAN names.
+* `department`: optional, specifies the department where the VLAN is used.
+* `contact`: optional, specifies the contact information for the person/team managing or using the VLAN.
+* `ext_attrs`: optional, specifies the set of NIOS extensible attributes that will be attached to the VLAN.
+
+You can modify the `name`, `vlan_id`, `comment`, `description`, `department`, `contact`, and `ext_attrs` parameters after the VLAN is created.
+
+### Finding the Parent Reference
+
+To find the parent reference for your VLAN View or VLAN Range, you can use the Infoblox WAPI:
+
+```bash
+# List all VLAN views
+curl -k -u "${INFOBLOX_USERNAME}:${INFOBLOX_PASSWORD}" \
+  "https://${INFOBLOX_SERVER}/wapi/v2.12/vlanview"
+
+# List all VLAN ranges
+curl -k -u "${INFOBLOX_USERNAME}:${INFOBLOX_PASSWORD}" \
+  "https://${INFOBLOX_SERVER}/wapi/v2.12/vlanrange"
+```
+
+### Example of VLAN Resource with Explicit VLAN ID
+
+```hcl
+resource "infoblox_vlan" "vlan100" {
+  parent      = "vlanview/ZG5zLnZsYW5fdmlldyRkZWZhdWx0:default/1/4094"
+  name        = "production-vlan"
+  vlan_id     = 100
+  comment     = "Production environment VLAN"
+  description = "VLAN for production workloads"
+  department  = "IT Operations"
+  contact     = "ops-team@example.com"
+  ext_attrs = jsonencode({
+    "Site"        = "Datacenter 1"
+    "Environment" = "Production"
+  })
+}
+```
+
+### Example of VLAN Resource with Auto-Allocated VLAN ID
+
+When `vlan_id` is not specified, the next available VLAN ID will be automatically allocated from the parent range:
+
+```hcl
+resource "infoblox_vlan" "auto_vlan" {
+  parent      = "vlanview/ZG5zLnZsYW5fdmlldyRkZWZhdWx0:default/1/4094"
+  name        = "auto-allocated-vlan"
+  comment     = "VLAN with auto-allocated ID"
+  # vlan_id is omitted - will be auto-allocated from the parent range
+}
+```
+
+After creation, you can reference the allocated VLAN ID using `infoblox_vlan.auto_vlan.vlan_id`.
+
+### Minimal Resource Block
+
+The minimal resource block required to create a VLAN is as follows:
+
+```hcl
+resource "infoblox_vlan" "simple_vlan" {
+  parent = "vlanview/ZG5zLnZsYW5fdmlldyRkZWZhdWx0:default/1/4094"
+  name   = "my-vlan"
+  # vlan_id will be auto-allocated
+}
+```
+
+Or with an explicit VLAN ID:
+
+```hcl
+resource "infoblox_vlan" "simple_vlan" {
+  parent  = "vlanview/ZG5zLnZsYW5fdmlldyRkZWZhdWx0:default/1/4094"
+  name    = "my-vlan"
+  vlan_id = 100
+}
+```
+
+### Import
+
+You can import existing VLANs using their NIOS reference:
+
+```shell
+terraform import infoblox_vlan.vlan100 vlan/ZG5zLnZsYW4kMTAw:default/my-vlan/100
+```
+
+**Note:** After importing, you must specify the `parent` field in your Terraform configuration, as it cannot be automatically read from the API due to a limitation in the Infoblox Go client.

--- a/examples/resources/infoblox_vlan.tf
+++ b/examples/resources/infoblox_vlan.tf
@@ -1,0 +1,29 @@
+resource "infoblox_vlan" "vlan100" {
+  name        = "production-vlan"
+  vlan_id     = 100
+  comment     = "Production environment VLAN"
+  description = "VLAN for production workloads"
+  department  = "IT Operations"
+  contact     = "ops-team@example.com"
+  ext_attrs = jsonencode({
+    "Site"        = "Datacenter 1"
+    "Environment" = "Production"
+    "Tenant ID"   = "terraform_test_tenant"
+  })
+}
+
+# Minimal example
+resource "infoblox_vlan" "simple_vlan" {
+  name    = "my-vlan"
+  vlan_id = 200
+}
+
+# Example with multiple attributes
+resource "infoblox_vlan" "dev_vlan" {
+  name        = "dev-vlan"
+  vlan_id     = 150
+  comment     = "Development VLAN"
+  description = "VLAN for development environment"
+  department  = "Engineering"
+  contact     = "dev-team@example.com"
+}

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -222,6 +222,7 @@ func Provider() *schema.Provider {
 			"infoblox_ipv4_range":             resourceRange(),
 			"infoblox_ipv4_range_template":    resourceRangeTemplate(),
 			"infoblox_ipv4_shared_network":    resourceIpv4SharedNetwork(),
+			"infoblox_vlan":                   resourceVlan(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"infoblox_ipv4_network":           dataSourceIPv4Network(),

--- a/infoblox/resource_infoblox_vlan.go
+++ b/infoblox/resource_infoblox_vlan.go
@@ -1,0 +1,464 @@
+package infoblox
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+)
+
+var (
+	vlanRegExp = regexp.MustCompile("^vlan/.+")
+)
+
+// VlanCreate is a custom struct for creating VLANs that supports both
+// numeric vlan_id and "func:nextavailablevlanid" function syntax.
+// This is needed because the standard Vlan struct has Id as *uint32.
+type VlanCreate struct {
+	ibclient.IBBase `json:"-"`
+
+	Ref         string          `json:"_ref,omitempty"`
+	Name        *string         `json:"name,omitempty"`
+	Id          interface{}     `json:"id,omitempty"` // Can be uint32 or string for func:nextavailablevlanid
+	Parent      *string         `json:"parent,omitempty"`
+	Comment     *string         `json:"comment,omitempty"`
+	Description *string         `json:"description,omitempty"`
+	Department  *string         `json:"department,omitempty"`
+	Contact     *string         `json:"contact,omitempty"`
+	Ea          ibclient.EA     `json:"extattrs,omitempty"`
+
+	returnFields []string
+}
+
+func (v VlanCreate) ObjectType() string {
+	return "vlan"
+}
+
+func (v VlanCreate) ReturnFields() []string {
+	return v.returnFields
+}
+
+func (v *VlanCreate) SetReturnFields(fields []string) {
+	v.returnFields = fields
+}
+
+func resourceVlan() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVlanCreate,
+		Read:   resourceVlanRead,
+		Update: resourceVlanUpdate,
+		Delete: resourceVlanDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVlanImport,
+		},
+		CustomizeDiff: func(context context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			if internalID := d.Get("internal_id"); internalID == "" || internalID == nil {
+				err := d.SetNewComputed("internal_id")
+				if err != nil {
+					return err
+				}
+			}
+			// Mark vlan_id as computed if not explicitly set (next available will be used)
+			if vlanId, ok := d.GetOk("vlan_id"); !ok || vlanId == 0 {
+				if d.Id() == "" { // Only for new resources
+					err := d.SetNewComputed("vlan_id")
+					if err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+
+		Schema: map[string]*schema.Schema{
+			"parent": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The VLAN View or VLAN Range to which this VLAN belongs (reference string).",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the VLAN.",
+			},
+			"vlan_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "VLAN ID value (typically 1-4094). If not specified, the next available VLAN ID will be allocated from the parent range.",
+			},
+			"comment": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "A descriptive comment for this VLAN.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "Description for the VLAN object, may be potentially used for longer VLAN names.",
+			},
+			"department": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "Department where VLAN is used.",
+			},
+			"contact": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "Contact information for person/team managing or using VLAN.",
+			},
+			"ext_attrs": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "The Extensible attributes of the VLAN to be added/updated, as a map in JSON format",
+			},
+			"internal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: "Internal ID of an object at NIOS side," +
+					" used by Infoblox Terraform plugin to search for a NIOS's object" +
+					" which corresponds to the Terraform resource.",
+			},
+			"ref": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "NIOS object's reference, not to be set by a user.",
+			},
+		},
+	}
+}
+
+func resourceVlanCreate(d *schema.ResourceData, m interface{}) error {
+	if intId := d.Get("internal_id"); intId.(string) != "" {
+		return fmt.Errorf("the value of 'internal_id' field must not be set manually")
+	}
+
+	parent := d.Get("parent").(string)
+	name := d.Get("name").(string)
+	comment := d.Get("comment").(string)
+	description := d.Get("description").(string)
+	department := d.Get("department").(string)
+	contact := d.Get("contact").(string)
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs, err := terraformDeserializeEAs(extAttrJSON)
+	if err != nil {
+		return err
+	}
+
+	connector := m.(ibclient.IBConnector)
+
+	// Generate UUID for internal_id and add to the EA
+	internalId := generateInternalId()
+	extAttrs[eaNameForInternalId] = internalId.String()
+
+	// Determine VLAN ID - use provided value or next available
+	var vlanIdValue interface{}
+	if v, ok := d.GetOk("vlan_id"); ok {
+		vlanIdValue = uint32(v.(int))
+	} else {
+		// Use next available VLAN ID function
+		vlanIdValue = fmt.Sprintf("func:nextavailablevlanid:%s", parent)
+	}
+
+	// Create VLAN object using custom struct that supports both numeric and function ID
+	vlan := &VlanCreate{
+		Parent:      &parent,
+		Name:        &name,
+		Id:          vlanIdValue,
+		Comment:     &comment,
+		Description: &description,
+		Department:  &department,
+		Contact:     &contact,
+		Ea:          extAttrs,
+	}
+	vlan.SetReturnFields([]string{"id", "name", "comment", "description", "department", "contact", "extattrs"})
+
+	ref, err := connector.CreateObject(vlan)
+	if err != nil {
+		return fmt.Errorf("failed to create VLAN: %s", err)
+	}
+
+	d.SetId(ref)
+	if err = d.Set("internal_id", internalId.String()); err != nil {
+		return err
+	}
+	if err = d.Set("ref", ref); err != nil {
+		return err
+	}
+
+	// Read back the VLAN to get the actual vlan_id (especially important for next available)
+	return resourceVlanRead(d, m)
+}
+
+func resourceVlanRead(d *schema.ResourceData, m interface{}) error {
+	extAttrJSON := d.Get("ext_attrs").(string)
+	extAttrs, err := terraformDeserializeEAs(extAttrJSON)
+	if err != nil {
+		return err
+	}
+
+	connector := m.(ibclient.IBConnector)
+
+	// Get VLAN object by ref
+	// Note: parent field is not included in return fields because the API returns it as an object
+	// but the Go client expects a string. Parent is already stored in state from creation.
+	vlan := &ibclient.Vlan{}
+	vlan.SetReturnFields([]string{"id", "name", "comment", "description", "department", "contact", "extattrs"})
+	err = connector.GetObject(vlan, d.Id(), ibclient.NewQueryParams(false, nil), vlan)
+	if err != nil {
+		if _, ok := err.(*ibclient.NotFoundError); ok {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("failed to get VLAN: %s", err.Error())
+	}
+
+	if !vlanRegExp.MatchString(vlan.Ref) {
+		return fmt.Errorf("reference '%s' for 'vlan' object has an invalid format", vlan.Ref)
+	}
+
+	delete(vlan.Ea, eaNameForInternalId)
+	omittedEAs := omitEAs(vlan.Ea, extAttrs)
+
+	if omittedEAs != nil && len(omittedEAs) > 0 {
+		eaJSON, err := terraformSerializeEAs(omittedEAs)
+		if err != nil {
+			return err
+		}
+		if err = d.Set("ext_attrs", eaJSON); err != nil {
+			return err
+		}
+	}
+
+	d.SetId(vlan.Ref)
+	if err = d.Set("ref", vlan.Ref); err != nil {
+		return err
+	}
+	if vlan.Name != nil {
+		if err = d.Set("name", *vlan.Name); err != nil {
+			return err
+		}
+	}
+	if vlan.Id != nil {
+		if err = d.Set("vlan_id", int(*vlan.Id)); err != nil {
+			return err
+		}
+	}
+	if vlan.Comment != nil {
+		if err = d.Set("comment", *vlan.Comment); err != nil {
+			return err
+		}
+	}
+	if vlan.Description != nil {
+		if err = d.Set("description", *vlan.Description); err != nil {
+			return err
+		}
+	}
+	if vlan.Department != nil {
+		if err = d.Set("department", *vlan.Department); err != nil {
+			return err
+		}
+	}
+	if vlan.Contact != nil {
+		if err = d.Set("contact", *vlan.Contact); err != nil {
+			return err
+		}
+	}
+	// Note: parent is not read back from API due to type mismatch in Go client.
+	// It's already stored in state and is ForceNew, so it can't change.
+
+	return nil
+}
+
+func resourceVlanUpdate(d *schema.ResourceData, m interface{}) error {
+	var updateSuccessful bool
+	defer func() {
+		// Reverting the state back, in case of a failure,
+		// otherwise Terraform will keep the values, which leaded to the failure,
+		// in the state file.
+		if !updateSuccessful {
+			prevName, _ := d.GetChange("name")
+			prevVlanId, _ := d.GetChange("vlan_id")
+			prevComment, _ := d.GetChange("comment")
+			prevDescription, _ := d.GetChange("description")
+			prevDepartment, _ := d.GetChange("department")
+			prevContact, _ := d.GetChange("contact")
+			prevEa, _ := d.GetChange("ext_attrs")
+
+			_ = d.Set("name", prevName.(string))
+			_ = d.Set("vlan_id", prevVlanId.(int))
+			_ = d.Set("comment", prevComment.(string))
+			_ = d.Set("description", prevDescription.(string))
+			_ = d.Set("department", prevDepartment.(string))
+			_ = d.Set("contact", prevContact.(string))
+			_ = d.Set("ext_attrs", prevEa.(string))
+		}
+	}()
+
+	if d.HasChange("internal_id") {
+		return fmt.Errorf("changing the value of 'internal_id' field is not allowed")
+	}
+
+	name := d.Get("name").(string)
+	vlanId := uint32(d.Get("vlan_id").(int))
+	comment := d.Get("comment").(string)
+	description := d.Get("description").(string)
+	department := d.Get("department").(string)
+	contact := d.Get("contact").(string)
+
+	oldExtAttrJSON, newExtAttrJSON := d.GetChange("ext_attrs")
+
+	newExtAttrs, err := terraformDeserializeEAs(newExtAttrJSON.(string))
+	if err != nil {
+		return err
+	}
+
+	oldExtAttrs, err := terraformDeserializeEAs(oldExtAttrJSON.(string))
+	if err != nil {
+		return err
+	}
+
+	connector := m.(ibclient.IBConnector)
+
+	// Get current VLAN object
+	// Note: parent field is not included due to type mismatch in Go client
+	vlan := &ibclient.Vlan{}
+	vlan.SetReturnFields([]string{"id", "name", "comment", "description", "department", "contact", "extattrs"})
+	err = connector.GetObject(vlan, d.Id(), ibclient.NewQueryParams(false, nil), vlan)
+	if err != nil {
+		return fmt.Errorf("failed to read VLAN for update operation: %w", err)
+	}
+
+	internalId := d.Get("internal_id").(string)
+
+	if internalId == "" {
+		internalId = generateInternalId().String()
+	}
+
+	newInternalId := newInternalResourceIdFromString(internalId)
+	newExtAttrs[eaNameForInternalId] = newInternalId.String()
+
+	updExtAttrs, err := mergeEAs(vlan.Ea, newExtAttrs, oldExtAttrs, connector)
+	if err != nil {
+		return err
+	}
+
+	// Update VLAN object
+	vlan.Name = &name
+	vlan.Id = &vlanId
+	vlan.Comment = &comment
+	vlan.Description = &description
+	vlan.Department = &department
+	vlan.Contact = &contact
+	vlan.Ea = updExtAttrs
+
+	updatedRef, err := connector.UpdateObject(vlan, d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to update VLAN: %s", err.Error())
+	}
+	updateSuccessful = true
+
+	if err = d.Set("internal_id", newInternalId.String()); err != nil {
+		return err
+	}
+	if err = d.Set("ref", updatedRef); err != nil {
+		return err
+	}
+	d.SetId(updatedRef)
+
+	return nil
+}
+
+func resourceVlanDelete(d *schema.ResourceData, m interface{}) error {
+	connector := m.(ibclient.IBConnector)
+
+	// Delete VLAN directly by reference
+	_, err := connector.DeleteObject(d.Id())
+	if err != nil {
+		if _, ok := err.(*ibclient.NotFoundError); ok {
+			// Already deleted, clear state
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("deletion of VLAN failed: %s", err.Error())
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceVlanImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	connector := m.(ibclient.IBConnector)
+
+	// Get VLAN object by ref
+	// Note: parent field is not included due to type mismatch in Go client.
+	// User must specify parent in their Terraform config after import.
+	vlan := &ibclient.Vlan{}
+	vlan.SetReturnFields([]string{"id", "name", "comment", "description", "department", "contact", "extattrs"})
+	err := connector.GetObject(vlan, d.Id(), ibclient.NewQueryParams(false, nil), vlan)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VLAN: %s", err.Error())
+	}
+
+	if !vlanRegExp.MatchString(d.Id()) {
+		return nil, fmt.Errorf("reference '%s' for 'vlan' object has an invalid format", d.Id())
+	}
+
+	if vlan.Ea != nil && len(vlan.Ea) > 0 {
+		eaJSON, err := terraformSerializeEAs(vlan.Ea)
+		if err != nil {
+			return nil, err
+		}
+		if err = d.Set("ext_attrs", eaJSON); err != nil {
+			return nil, err
+		}
+	}
+
+	d.SetId(vlan.Ref)
+	if vlan.Name != nil {
+		if err = d.Set("name", *vlan.Name); err != nil {
+			return nil, err
+		}
+	}
+	if vlan.Id != nil {
+		if err = d.Set("vlan_id", int(*vlan.Id)); err != nil {
+			return nil, err
+		}
+	}
+	if vlan.Comment != nil {
+		if err = d.Set("comment", *vlan.Comment); err != nil {
+			return nil, err
+		}
+	}
+	if vlan.Description != nil {
+		if err = d.Set("description", *vlan.Description); err != nil {
+			return nil, err
+		}
+	}
+	if vlan.Department != nil {
+		if err = d.Set("department", *vlan.Department); err != nil {
+			return nil, err
+		}
+	}
+	if vlan.Contact != nil {
+		if err = d.Set("contact", *vlan.Contact); err != nil {
+			return nil, err
+		}
+	}
+	// Note: parent is not read from API due to type mismatch. User must specify it in config.
+
+	// Update the resource with the EA Terraform Internal ID
+	err = resourceVlanUpdate(d, m)
+	if err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/infoblox/resource_infoblox_vlan_test.go
+++ b/infoblox/resource_infoblox_vlan_test.go
@@ -1,0 +1,279 @@
+package infoblox
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/infobloxopen/infoblox-go-client/v2/utils"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+)
+
+func testAccCheckVlanDestroy(s *terraform.State) error {
+	meta := testAccProvider.Meta()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "infoblox_vlan" {
+			continue
+		}
+		connector := meta.(ibclient.IBConnector)
+		objMgr := ibclient.NewObjectManager(connector, "terraform_test", "test")
+		vlan := ibclient.NewEmptyVlan()
+		err := connector.GetObject(vlan, rs.Primary.ID, ibclient.NewQueryParams(false, nil), vlan)
+		if err == nil {
+			return fmt.Errorf("VLAN still exists")
+		}
+		// Suppress unused variable warning
+		_ = objMgr
+	}
+	return nil
+}
+
+func testAccVlanCompare(t *testing.T, resPath string, expectedRec *ibclient.Vlan) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, found := s.RootModule().Resources[resPath]
+		if !found {
+			return fmt.Errorf("Not found: %s", resPath)
+		}
+
+		internalId := res.Primary.Attributes["internal_id"]
+		if internalId == "" {
+			return fmt.Errorf("ID is not set")
+		}
+
+		ref, found := res.Primary.Attributes["ref"]
+		if !found {
+			return fmt.Errorf("'ref' attribute is not set")
+		}
+
+		if res.Primary.ID == "" {
+			return fmt.Errorf("ID is not set")
+		}
+
+		connector := testAccProvider.Meta().(ibclient.IBConnector)
+		objMgr := ibclient.NewObjectManager(
+			connector,
+			"terraform_test",
+			"test")
+		obj, err := objMgr.SearchObjectByAltId("Vlan", ref, internalId, eaNameForInternalId)
+		if err != nil {
+			if isNotFoundError(err) {
+				if expectedRec == nil {
+					return nil
+				}
+				return fmt.Errorf("object with Terraform ID '%s' not found, but expected to exist", internalId)
+			}
+		}
+		// Assertion of object type and error handling
+		var rec *ibclient.Vlan
+		recJson, _ := json.Marshal(obj)
+		err = json.Unmarshal(recJson, &rec)
+
+		if rec.Name == nil {
+			return fmt.Errorf("VLAN's 'name' field is expected to be defined but it is not")
+		}
+		if *rec.Name != *expectedRec.Name {
+			return fmt.Errorf(
+				"'name' does not match: got '%s', expected '%s'",
+				*rec.Name,
+				*expectedRec.Name)
+		}
+
+		if rec.Id == nil {
+			return fmt.Errorf("VLAN's 'id' field is expected to be defined but it is not")
+		}
+		if *rec.Id != *expectedRec.Id {
+			return fmt.Errorf(
+				"'id' does not match: got '%d', expected '%d'",
+				*rec.Id,
+				*expectedRec.Id)
+		}
+
+		if rec.Comment != nil {
+			if expectedRec.Comment == nil {
+				return fmt.Errorf("'comment' is expected to be undefined but it is not")
+			}
+			if *rec.Comment != *expectedRec.Comment {
+				return fmt.Errorf(
+					"'comment' does not match: got '%s', expected '%s'",
+					*rec.Comment, *expectedRec.Comment)
+			}
+		} else if expectedRec.Comment != nil {
+			return fmt.Errorf("'comment' is expected to be defined but it is not")
+		}
+
+		if rec.Description != nil {
+			if expectedRec.Description == nil {
+				return fmt.Errorf("'description' is expected to be undefined but it is not")
+			}
+			if *rec.Description != *expectedRec.Description {
+				return fmt.Errorf(
+					"'description' does not match: got '%s', expected '%s'",
+					*rec.Description, *expectedRec.Description)
+			}
+		} else if expectedRec.Description != nil {
+			return fmt.Errorf("'description' is expected to be defined but it is not")
+		}
+
+		if rec.Department != nil {
+			if expectedRec.Department == nil {
+				return fmt.Errorf("'department' is expected to be undefined but it is not")
+			}
+			if *rec.Department != *expectedRec.Department {
+				return fmt.Errorf(
+					"'department' does not match: got '%s', expected '%s'",
+					*rec.Department, *expectedRec.Department)
+			}
+		} else if expectedRec.Department != nil {
+			return fmt.Errorf("'department' is expected to be defined but it is not")
+		}
+
+		if rec.Contact != nil {
+			if expectedRec.Contact == nil {
+				return fmt.Errorf("'contact' is expected to be undefined but it is not")
+			}
+			if *rec.Contact != *expectedRec.Contact {
+				return fmt.Errorf(
+					"'contact' does not match: got '%s', expected '%s'",
+					*rec.Contact, *expectedRec.Contact)
+			}
+		} else if expectedRec.Contact != nil {
+			return fmt.Errorf("'contact' is expected to be defined but it is not")
+		}
+
+		return validateEAs(rec.Ea, expectedRec.Ea)
+	}
+}
+
+func TestAccResourceVlan(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "infoblox_vlan" "foo"{
+						name = "test-vlan"
+						vlan_id = 100
+						comment = "test comment 1"
+						description = "Test VLAN description"
+						department = "IT"
+						contact = "admin@example.com"
+						ext_attrs = jsonencode({
+							"Tenant ID"="terraform_test_tenant"
+							"Location"="Test loc"
+						})
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVlanCompare(t, "infoblox_vlan.foo", &ibclient.Vlan{
+						Name:        utils.StringPtr("test-vlan"),
+						Id:          utils.Uint32Ptr(100),
+						Comment:     utils.StringPtr("test comment 1"),
+						Description: utils.StringPtr("Test VLAN description"),
+						Department:  utils.StringPtr("IT"),
+						Contact:     utils.StringPtr("admin@example.com"),
+						Ea: ibclient.EA{
+							"Tenant ID": "terraform_test_tenant",
+							"Location":  "Test loc",
+						},
+					}),
+				),
+			},
+			// When extensible attributes are added by another tool,
+			// terraform shouldn't remove those EAs
+			{
+				PreConfig: func() {
+					conn := testAccProvider.Meta().(ibclient.IBConnector)
+
+					vlan := ibclient.NewEmptyVlan()
+					vlan.SetReturnFields(append(vlan.ReturnFields(), "extattrs"))
+
+					qp := ibclient.NewQueryParams(
+						false,
+						map[string]string{
+							"name": "test-vlan",
+						},
+					)
+					var res []ibclient.Vlan
+					err := conn.GetObject(vlan, "", qp, &res)
+					if err != nil {
+						panic(err)
+					}
+
+					res[0].Ea["Site"] = "Test site"
+
+					_, err = conn.UpdateObject(&res[0], res[0].Ref)
+					if err != nil {
+						panic(err)
+					}
+				},
+				Config: `
+					resource "infoblox_vlan" "foo"{
+						name = "test-vlan"
+						vlan_id = 100
+						comment = "test comment 1"
+						description = "Test VLAN description"
+						department = "IT"
+						contact = "admin@example.com"
+						ext_attrs = jsonencode({
+							"Tenant ID"="terraform_test_tenant"
+							"Location"="Test loc"
+						})
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					// Resource object shouldn't have Site, since it's omitted by provider
+					resource.TestCheckResourceAttr(
+						"infoblox_vlan.foo", "ext_attrs",
+						`{"Location":"Test loc","Tenant ID":"terraform_test_tenant"}`,
+					),
+					// Actual API object should have Site EA
+					testAccVlanCompare(t, "infoblox_vlan.foo", &ibclient.Vlan{
+						Name:        utils.StringPtr("test-vlan"),
+						Id:          utils.Uint32Ptr(100),
+						Comment:     utils.StringPtr("test comment 1"),
+						Description: utils.StringPtr("Test VLAN description"),
+						Department:  utils.StringPtr("IT"),
+						Contact:     utils.StringPtr("admin@example.com"),
+						Ea: ibclient.EA{
+							"Tenant ID": "terraform_test_tenant",
+							"Location":  "Test loc",
+							"Site":      "Test site",
+						},
+					}),
+				),
+			},
+			// Validate that inherited EA won't be removed if some field is updated in the resource
+			{
+				Config: `
+					resource "infoblox_vlan" "foo"{
+						name = "test-vlan"
+						vlan_id = 100
+						comment = "Updated test comment"
+						description = "Updated VLAN description"
+						department = "Engineering"
+						contact = "eng@example.com"
+						ext_attrs = jsonencode({
+							"Tenant ID"="terraform_test_tenant"
+							"Location"="Test loc"
+						})
+					}`,
+				Check: testAccVlanCompare(t, "infoblox_vlan.foo", &ibclient.Vlan{
+					Name:        utils.StringPtr("test-vlan"),
+					Id:          utils.Uint32Ptr(100),
+					Comment:     utils.StringPtr("Updated test comment"),
+					Description: utils.StringPtr("Updated VLAN description"),
+					Department:  utils.StringPtr("Engineering"),
+					Contact:     utils.StringPtr("eng@example.com"),
+					Ea: ibclient.EA{
+						"Tenant ID": "terraform_test_tenant",
+						"Location":  "Test loc",
+						"Site":      "Test site",
+					},
+				}),
+			},
+		},
+	})
+}

--- a/test-vlan.tf
+++ b/test-vlan.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    infoblox = {
+      source = "infobloxopen/infoblox"
+    }
+  }
+}
+
+provider "infoblox" {
+  server   = "100.68.0.149"
+  username = "admin"
+  password = "infoblox"
+}
+
+resource "infoblox_vlan" "test_vlan" {
+    parent  = "vlanview/ZG5zLnZsYW5fdmlldyRJQUMtQkdQLUFTLU5VTS42MDEuOTk5:IAC-BGP-AS-NUM/601/999"
+    name    = "auto-vlan"
+    comment = "VLAN with auto-allocated ID"
+    # vlan_id is omitted - will be auto-allocated
+  }
+  resource "infoblox_vlan" "test_vlanx" {
+    parent  = "vlanview/ZG5zLnZsYW5fdmlldyRJQUMtQkdQLUFTLU5VTS42MDEuOTk5:IAC-BGP-AS-NUM/601/999"
+    name    = "auto-vlanx"
+    comment = "VLAN with auto-allocated ID"
+    # vlan_id is omitted - will be auto-allocated
+  }


### PR DESCRIPTION
- Introduced `infoblox_vlan` resource for managing VLANs in NIOS.
- Added required `parent` field and made `vlan_id` optional for auto-allocation.
- Implemented CRUD operations with error handling.
- Updated documentation with usage examples for explicit and auto-allocated VLAN IDs.
- Added tests to validate VLAN resource functionality.