### PR TITLE
feat: expose vlan reference in vlans block of network datasource

### DIFF
--- a/docs/data-sources/infoblox_ipv4_network.md
+++ b/docs/data-sources/infoblox_ipv4_network.md
@@ -25,10 +25,12 @@ options {
 * `vlans`: An array of VLAN structs that lists the VLANs associated with the network object.  
     * `id`: The unique identifier of the VLAN object in Infoblox. Example: `201`
     * `name`: The name of the VLAN as defined in Infoblox. Example: `PROD-APP-100`
+    * `vlan`: The full Infoblox VLAN reference (object ref). Example: `vlan/.../201`
 ```terraform
 vlans {
     id          = 201
     name        = "PROD-APP-100"
+    vlan        = "vlan/ZG5zLnZsYW4k.../201"
   }
 ```
 * `utilization`: The network utilization in percentage. Example: `0`

--- a/infoblox/datasource_infoblox_network.go
+++ b/infoblox/datasource_infoblox_network.go
@@ -70,6 +70,12 @@ func dataSourceNetwork() *schema.Resource {
 										Computed:    true,
 										Description: "Name of the VLAN as defined in Infoblox.",
 									},
+
+									"vlan": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Full VLAN reference (Infoblox object ref)",
+									},
 								},
 							},
 						},
@@ -130,6 +136,7 @@ func flattenVlans(vlans []*ibclient.Vlanlink) []interface{} {
 		m := map[string]interface{}{
 			"id":   int(v.Id),
 			"name": v.Name,
+			"vlan": v.Vlan,
 		}
 
 		result = append(result, m)

--- a/vendor/github.com/infobloxopen/infoblox-go-client/v2/objects_generated.go
+++ b/vendor/github.com/infobloxopen/infoblox-go-client/v2/objects_generated.go
@@ -28094,6 +28094,9 @@ type Vlanlink struct {
 
 	// Name of the VLAN.
 	Name string `json:"name,omitempty"`
+
+	// Vlan ref value
+	Vlan string `json:"vlan,omitempty"`
 }
 
 // Vtftpdirmember represents Infoblox struct vtftpdirmember


### PR DESCRIPTION
## Description

### Summary

This PR enhances the Infoblox network data source by exposing the full VLAN reference returned by the WAPI.

### Changes

* Added new field `vlan` in the `vlans` block of the datasource schema
* Updated `flattenVlans` to include the VLAN reference (`v.Vlan`)
* Updated documentation to reflect the new attribute

### Example

#### Before

```hcl
vlans {
  id   = 201
  name = "PROD-APP-100"
}
```

#### After

```hcl
vlans {
  id    = 201
  name  = "PROD-APP-100"
  vlan  = "vlan/.../201"
}
```

***

### Motivation

The Infoblox WAPI returns a `vlan` field containing the full object reference, but it was not previously exposed in the Terraform provider.

Providing this attribute allows:

* easier integration with other Infoblox objects
* more advanced automation workflows
* access to the full object reference when needed
