### PR TITLE
fix: mark ipv4addr as Computed for dynamic allocation

### DIFF
--- a/infoblox/resource_infoblox_fixed_address.go
+++ b/infoblox/resource_infoblox_fixed_address.go
@@ -70,6 +70,7 @@ func resourceFixedRecord() *schema.Resource {
 			"ipv4addr": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The IPv4 Address of the fixed address.",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					oldNetwork, _ := d.GetChange("network")


### PR DESCRIPTION
Hi team, quick intro since I'm new around here: I'm Nishchay, a product management intern at Infoblox (Santa Clara HQ). I like contributing to OSS on the side, and since I've been getting familiar with the team's projects I wanted to start pitching in.

Fixes #496.

`infoblox_ip_fixed_address` marks `ipv4addr` as `Optional` but not `Computed`. When you use dynamic allocation (pass `network` and leave `ipv4addr` blank), Terraform doesn't know the address will exist after apply, so you can't reference it from other resources at plan time.

This marks `ipv4addr` as `Computed` as well, matching how `infoblox_ip_allocation` already handles `allocated_ipv4_addr`. The change is safe here: the existing `DiffSuppressFunc` on the field and the `d.Set("ipv4addr", ...)` calls in the read/create path already populate the value after apply, so `Optional + Computed` won't produce an inconsistent result.

```go
"ipv4addr": {
    Type:        schema.TypeString,
    Optional:    true,
    Computed:    true,   // added
    Description: "The IPv4 Address of the fixed address.",
    ...
}
```

One honest note on testing: this is a schema-only change and I verified it by inspection against the working `infoblox_ip_allocation` resource, but I wasn't able to run the acceptance suite since it needs a live Infoblox grid. Happy to adjust anything if you'd like it done differently.