### PR TITLE
[ALL] Enhance acctest with configurable test execution controls

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -40,8 +40,7 @@ var (
 	// UDDIClient is used for UDDI verification tests
 	UDDIClient *uddiclient.APIClient
 
-	// ProtoV6ProviderFactories are used to instantiate a provider during
-	// acceptance testing.
+	// ProtoV6ProviderFactories instantiates the infoblox provider for acceptance testing.
 	ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"infoblox": providerserver.NewProtocol6WithError(provider.New("test", "test")()),
 	}
@@ -93,8 +92,7 @@ func PreCheckUDDI(t *testing.T) {
 	)
 }
 
-// PreCheck validates the test environment based on backend.
-// Use PreCheckNIOS or PreCheckUDDI directly when backend is known.
+// PreCheck validates the test environment for the given backend ("nios" or "uddi").
 func PreCheck(t *testing.T, backend string) {
 	switch backend {
 	case "nios":
@@ -120,9 +118,8 @@ func RandomNameWithPrefix(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, RandomName())
 }
 
-// RandomIP generates a random private IP address with valid host octet (1-254).
+// RandomIP generates a random private IPv4 address in the 10.x.x.x range.
 func RandomIP() string {
-	// Use 10.x.x.x private range with valid host octet
 	return fmt.Sprintf("10.%d.%d.%d", rand.Intn(256), rand.Intn(256), 1+rand.Intn(254))
 }
 
@@ -131,8 +128,7 @@ func RandomOctet() int {
 	return rand.Intn(256)
 }
 
-// RandomIPWithSpecificOctetsSet generates a random IP address with the first three octets set to the given prefix.
-// Last octet is 1-254 (valid host range, excludes 0=network and 255=broadcast).
+// RandomIPWithSpecificOctetsSet returns an IP with the given prefix and a random last octet (1-254).
 func RandomIPWithSpecificOctetsSet(prefix string) string {
 	return fmt.Sprintf("%s.%d", prefix, 1+rand.Intn(254))
 }
@@ -145,9 +141,8 @@ func RandomNumber(maxLimit int) int {
 	return rand.Intn(maxLimit)
 }
 
-// RandomCIDRNetwork generates a random network with specific CIDR
+// RandomCIDRNetwork generates a random IPv4 network in CIDR notation (/16-/24).
 func RandomCIDRNetwork() string {
-	// Generate test-suitable private networks
 	base := 10 + rand.Intn(246) // 10-255 for first octet
 	second := rand.Intn(256)    // 0-255 for second octet
 	cidr := 16 + rand.Intn(9)   // /16 to /24 (common for network containers)
@@ -155,10 +150,8 @@ func RandomCIDRNetwork() string {
 	return fmt.Sprintf("%d.%d.0.0/%d", base, second, cidr)
 }
 
-// RandomIPv6Network generates a random IPv6 network with specific CIDR
+// RandomIPv6Network generates a random IPv6 network under 2001:db8::/32 (RFC 3849 test range).
 func RandomIPv6Network() string {
-	// Generate a random IPv6 network using the documentation prefix 2001:db8::/32
-	// This is reserved for documentation and testing purposes (RFC 3849)
 	third := rand.Intn(65536)  // 0-FFFF for third hextet
 	fourth := rand.Intn(65536) // 0-FFFF for fourth hextet
 	cidr := 64 + rand.Intn(60)
@@ -176,7 +169,7 @@ func RandomAlphaNumeric(length int) string {
 	return string(b)
 }
 
-// RandomMACAddress generates a random MAC address
+// RandomMACAddress generates a random MAC address.
 func RandomMACAddress() string {
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
 		rand.Intn(256),
@@ -187,9 +180,8 @@ func RandomMACAddress() string {
 		rand.Intn(256))
 }
 
-// Random32Hexadecimal generates a random 32-character hexadecimal string
+// Random32Hexadecimal generates a random 32-character hexadecimal string.
 func Random32Hexadecimal() string {
-	// Two 64-bit random values = 128 bits = 32 hex characters
 	return fmt.Sprintf("%016x%016x", rand.Uint64(), rand.Uint64())
 }
 
@@ -208,16 +200,9 @@ func GetTestdataPath(relativePath string) string {
 	return filepath.Join(packageDir, "testdata", relativePath)
 }
 
-// ResolvePlaceholder returns a freshly generated concrete value for a single
-// placeholder token (e.g. "{{random_ipv6_network}}"). Function-specific
-// placeholders round-trip to the matching acctest.Random* generator so a value
-// produced by a function in the legacy test keeps that function's format
-// (IPv6 network, CIDR, IP, MAC, hex, ...) instead of collapsing to a plain
-// name token. A trailing numeric disambiguator (e.g. "{{random2}}") is matched
-// against its base so distinct vars of the same type still resolve correctly.
-//
-// Ordering note: more specific bases must precede their prefixes (e.g.
-// random_ipv6_network before random_ip, random_int before random_ip).
+// ResolvePlaceholder returns a concrete value for a single placeholder token (e.g. "{{random_ip}}").
+// Each token maps to its matching Random* generator; unrecognised tokens produce a random name.
+// More-specific prefixes must appear before shorter ones (e.g. random_ipv6_network before random_ip).
 func ResolvePlaceholder(placeholder string) string {
 	name := strings.TrimSuffix(strings.TrimPrefix(placeholder, "{{"), "}}")
 	switch {
@@ -248,20 +233,8 @@ func ResolvePlaceholder(placeholder string) string {
 	}
 }
 
-// ReplacePlaceholders replaces template placeholders with random values.
-// Supported placeholders:
-//   - {{random}} - Random string (e.g., "tf-acc-test-abc123")
-//   - {{random_octet}} - Random 1-254 (valid IP host range, excludes 0=network and 255=broadcast)
-//   - {{random_int}} - Random integer 1-9999
-//   - {{random_ip}} - Random private IPv4 host address
-//   - {{random_cidr_network}} - Random IPv4 network in CIDR notation
-//   - {{random_ipv6_network}} - Random IPv6 network in CIDR notation
-//   - {{random_mac}} - Random MAC address
-//   - {{random_hex32}} - Random 32-character hexadecimal string
-//   - {{grid_master_hostname}} - NIOS_GRID_MASTER_HOSTNAME env var
-//   - {{grid_member_hostname}} - NIOS_GRID_MEMBER_HOSTNAME env var
-//   - {{discovery_member_hostname}} - NIOS_DISCOVERY_MEMBER_HOSTNAME env var
-//   - {{pxgrid_endpoint_ref}} - NIOS_PXGRID_ENDPOINT_REF env var
+// ReplacePlaceholders substitutes all {{token}} placeholders in content with random or env-sourced values.
+// See ResolvePlaceholder for the full token list.
 func ReplacePlaceholders(content string) string {
 	result := content
 	for _, ph := range placeholderPattern.FindAllString(content, -1) {
@@ -270,8 +243,7 @@ func ReplacePlaceholders(content string) string {
 	return result
 }
 
-// ProviderConfigHCL returns provider configuration HCL for the given backend.
-// It reads credentials from environment variables.
+// ProviderConfigHCL returns provider HCL for backend ("nios" or "uddi"), reading credentials from env.
 func ProviderConfigHCL(backend string) string {
 	switch backend {
 	case "nios":

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -234,7 +234,7 @@ func ResolvePlaceholder(placeholder string) string {
 }
 
 // ReplacePlaceholders substitutes all {{token}} placeholders in content with random or env-sourced values.
-// See ResolvePlaceholder for the full token list.
+// See ResolvePlaceholder for the full token list data.
 func ReplacePlaceholders(content string) string {
 	result := content
 	for _, ph := range placeholderPattern.FindAllString(content, -1) {

--- a/internal/acctest/builder.go
+++ b/internal/acctest/builder.go
@@ -44,10 +44,8 @@ func BuildResourceHCL(resourceType, resourceLabel string, tv *Tfvars) string {
 	return sb.String()
 }
 
-// RawExpr is an HCL expression captured verbatim from a tfvars file (for
-// example a reference to another resource, like
-// ${infoblox_zone_auth.prereq.fqdn}). It is emitted unquoted so Terraform
-// resolves it at apply time instead of being treated as a string literal.
+// RawExpr is a verbatim HCL expression (e.g. a resource reference like ${infoblox_zone_auth.prereq.fqdn})
+// emitted unquoted so Terraform resolves it at apply time instead of treating it as a string literal.
 type RawExpr string
 
 func formatHCLValue(v any) string {

--- a/internal/acctest/cases.go
+++ b/internal/acctest/cases.go
@@ -29,6 +29,10 @@ type CaseStep struct {
 	UDDI      map[string]any
 	Checks    map[string]string
 	DependsOn []string
+	// PrerequisitesHCL overrides ResourceCase.PrerequisitesHCL for this step. It
+	// is set only when a case's steps need different prerequisites — e.g. a view
+	// case where the auth zone moves between DNS views along with the record.
+	PrerequisitesHCL string
 }
 
 // ResourceCase is a per-test-case acceptance configuration, generated from the
@@ -103,7 +107,11 @@ func runResourceCase(t *testing.T, resourceType string, rc *ResourceCase, checks
 	var steps []resource.TestStep
 	for i, st := range rc.Steps {
 		config := buildCaseHCL(resourceType, "test", rc.Backend, st)
-		fullConfig := providerConfig + "\n" + rc.PrerequisitesHCL + "\n" + config
+		prereq := rc.PrerequisitesHCL
+		if st.PrerequisitesHCL != "" {
+			prereq = st.PrerequisitesHCL
+		}
+		fullConfig := providerConfig + "\n" + prereq + "\n" + config
 
 		t.Logf("Case %q step %d HCL:\n%s", rc.Name, i+1, fullConfig)
 
@@ -194,15 +202,26 @@ func (rc *ResourceCase) materialize() {
 		return v
 	}
 
-	replace := func(v any) any {
-		s, ok := v.(string)
-		if !ok {
-			return v
-		}
+	substitute := func(s string) string {
 		for _, ph := range placeholderPattern.FindAllString(s, -1) {
 			s = strings.ReplaceAll(s, ph, value(ph))
 		}
 		return s
+	}
+
+	replace := func(v any) any {
+		switch t := v.(type) {
+		case RawExpr:
+			// A raw HCL expression can still embed placeholders — e.g.
+			// "{{random}}.${infoblox_zone_auth.test.nios.fqdn}", which is captured
+			// verbatim because it references another resource. Substitute inside
+			// it and keep it raw.
+			return RawExpr(substitute(string(t)))
+		case string:
+			return substitute(t)
+		default:
+			return v
+		}
 	}
 
 	// replaceDeep recurses into nested objects/lists (e.g. members, options,
@@ -237,6 +256,9 @@ func (rc *ResourceCase) materialize() {
 	}
 
 	for i := range rc.Steps {
+		if s, ok := replace(rc.Steps[i].PrerequisitesHCL).(string); ok {
+			rc.Steps[i].PrerequisitesHCL = s
+		}
 		replaceMap(rc.Steps[i].Common)
 		replaceMap(rc.Steps[i].NIOS)
 		replaceMap(rc.Steps[i].UDDI)
@@ -398,6 +420,7 @@ func parseCaseStep(body hcl.Body, src []byte) (CaseStep, error) {
 		Attributes: []hcl.AttributeSchema{
 			{Name: "check"},
 			{Name: "depends_on"},
+			{Name: "prerequisites_hcl"},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "common"},
@@ -412,6 +435,11 @@ func parseCaseStep(body hcl.Body, src []byte) (CaseStep, error) {
 	if attr, ok := content.Attributes["check"]; ok {
 		val, _ := attr.Expr.Value(nil)
 		st.Checks = ctyMapToStringMap(val)
+	}
+
+	if attr, ok := content.Attributes["prerequisites_hcl"]; ok {
+		val, _ := attr.Expr.Value(nil)
+		st.PrerequisitesHCL = val.AsString()
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {

--- a/internal/acctest/cases.go
+++ b/internal/acctest/cases.go
@@ -15,40 +15,8 @@ import (
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/core"
 )
 
-// # Acceptance test infrastructure – verification flow
-//
-// Test cases for every object are generated from the legacy hand-written tests
-// and stored as HCL `case "<name>" { ... }` blocks in the testdata directory:
-//
-//	testdata/<pkg>/<object>/<backend>_resources.tfvars   – resource cases
-//	testdata/<pkg>/<object>/<backend>_datasources.tfvars – data source cases
-//	testdata/<pkg>/<object>/<backend>_lists.tfvars       – list/query cases
-//
-// Each file carries the field values that were exercised in the original test.
-// At runtime the framework reads those values, builds Terraform HCL on the fly,
-// applies it against a live backend, and then verifies the API round-tripped the
-// values correctly. Verification strategy per test type:
-//
-//   - Resource (RunResourceCases / runResourceCase):
-//     step.Checks (key → literal string) → resource.TestCheckResourceAttr
-//     One check per scalar field declared in the case.
-//
-//   - Datasource (RunDataSourceCases / runDataSourceCase):
-//     (a) step config scalar fields → resource.TestCheckResourceAttrPair
-//         asserts data.results.0.<path> == resource.<path> for each field.
-//     (b) PairChecks (extracted from legacy testAccCheck*AttrPair helpers) →
-//         additional resource.TestCheckResourceAttrPair for fields not in the
-//         step config (e.g. fields set by the server, like absolute_name_spec).
-//
-//   - List (RunListCases / runListCase):
-//     Step 1 creates the resource; step 2 runs a list/query and asserts:
-//     (a) querycheck.ExpectLength[AtLeast] – correct number of results.
-//     (b) querycheck.ExpectResourceKnownValues – every scalar literal field
-//         from the create step appears with the same value in the query result.
-
-// ExtractNIOSRef strips the leading object-type segment from a full NIOS _ref
-// (e.g. "record:a/ZG5z..." -> "ZG5z..."). Acceptance check helpers that call
-// the raw NIOS SDK must use this, since the SDK re-applies the type prefix.
+// ExtractNIOSRef strips the object-type prefix from a NIOS _ref (e.g. "record:a/ZG5z..." -> "ZG5z..."),
+// since the raw NIOS SDK re-applies the prefix and would otherwise double it.
 func ExtractNIOSRef(ref string) string {
 	return core.ExtractNIOSRef(ref)
 }
@@ -60,17 +28,12 @@ type CaseStep struct {
 	UDDI      map[string]any
 	Checks    map[string]string
 	DependsOn []string
-	// PrerequisitesHCL overrides ResourceCase.PrerequisitesHCL for this step. It
-	// is set only when a case's steps need different prerequisites — e.g. a view
-	// case where the auth zone moves between DNS views along with the record.
+	// PrerequisitesHCL overrides ResourceCase.PrerequisitesHCL for steps that need different prereqs.
 	PrerequisitesHCL string
 }
 
-// ResourceCase is a per-test-case acceptance configuration, generated from the
-// legacy provider's hand-written acceptance tests. Each case maps 1:1 to a
-// legacy TestAcc<Object>Resource_<Case> function and is stored as a labelled
-// `case "<name>" { ... }` block in the merged
-// testdata/<package>/<object>/<backend>_resources.tfvars file.
+// ResourceCase is the per-subtest configuration for a Terraform resource acceptance test.
+// Each case maps to a `case "<name>" { ... }` block in <backend>_resources.tfvars.
 type ResourceCase struct {
 	Name               string
 	Backend            string
@@ -85,11 +48,8 @@ type ResourceCase struct {
 
 var placeholderPattern = regexp.MustCompile(`\{\{[a-z0-9_]+\}\}`)
 
-// RunResourceCases loads every `case "<name>" { ... }` block from the merged
-// tfvars file at testdata/<fileRelPath> and runs each as an independent
-// subtest, replaying its steps verbatim. checksByBackend supplies the
-// verification functions for each backend a case may target (e.g. "nios",
-// "uddi").
+// RunResourceCases loads all `case` blocks from testdata/<fileRelPath> and runs each as an independent
+// subtest, replaying its steps. checksByBackend provides verification functions per backend.
 func RunResourceCases(t *testing.T, resourceType, fileRelPath string, checksByBackend map[string]CheckFuncs) {
 	path := GetTestdataPath(fileRelPath)
 	cases, err := loadResourceCases(path)
@@ -97,8 +57,7 @@ func RunResourceCases(t *testing.T, resourceType, fileRelPath string, checksByBa
 		cases = nil
 	}
 
-	// Append user-authored custom cases from the sibling custom_<file> so custom
-	// scenarios written by users run automatically alongside the generated ones.
+	// Also run custom cases from the sibling custom_<file>.
 	customCases, mErr := loadCustomResourceCases(fileRelPath)
 	if mErr != nil {
 		t.Fatalf("failed to load custom resource cases for %s: %v", fileRelPath, mErr)
@@ -153,8 +112,6 @@ func runResourceCase(t *testing.T, resourceType string, rc *ResourceCase, checks
 		if rc.Disappears && checks.Disappears != nil {
 			checkFuncs = append(checkFuncs, checks.Disappears(resourceAddr))
 		}
-		// Values come from step.Checks, populated at generation time from the
-		// legacy test's resource.TestCheckResourceAttr calls.
 		for attr, expected := range st.Checks {
 			checkFuncs = append(checkFuncs, resource.TestCheckResourceAttr(resourceAddr, attr, expected))
 		}
@@ -220,9 +177,7 @@ func buildCaseHCL(resourceType, label, backend string, st CaseStep) string {
 	return sb.String()
 }
 
-// materialize replaces placeholders (e.g. {{random}}) with concrete values,
-// keeping each distinct placeholder consistent across all steps and checks of
-// the case so that, for example, a name used in config matches its check.
+// materialize replaces {{placeholder}} tokens with stable concrete values across all steps and checks.
 func (rc *ResourceCase) materialize() {
 	cache := make(map[string]string)
 
@@ -245,10 +200,7 @@ func (rc *ResourceCase) materialize() {
 	replace := func(v any) any {
 		switch t := v.(type) {
 		case RawExpr:
-			// A raw HCL expression can still embed placeholders — e.g.
-			// "{{random}}.${infoblox_zone_auth.test.nios.fqdn}", which is captured
-			// verbatim because it references another resource. Substitute inside
-			// it and keep it raw.
+			// RawExpr values may still contain placeholders; substitute and keep raw.
 			return RawExpr(substitute(string(t)))
 		case string:
 			return substitute(t)
@@ -257,9 +209,7 @@ func (rc *ResourceCase) materialize() {
 		}
 	}
 
-	// replaceDeep recurses into nested objects/lists (e.g. members, options,
-	// ext_attrs) so placeholders inside nested attribute values are materialized
-	// too, keeping each distinct placeholder consistent across the whole case.
+	// replaceDeep recurses into nested objects/lists so placeholders inside nested attributes are also materialized.
 	var replaceDeep func(v any) any
 	replaceDeep = func(v any) any {
 		switch val := v.(type) {
@@ -303,10 +253,8 @@ func (rc *ResourceCase) materialize() {
 	}
 }
 
-// customSibling returns the "custom_"-prefixed sibling of a testdata-relative
-// case file (e.g. "dns/record_a/nios_resources.tfvars" ->
-// "dns/record_a/custom_nios_resources.tfvars"). Custom files are hand-authored
-// by users to add custom scenarios and are never overwritten by codegen.
+// customSibling returns the "custom_"-prefixed sibling path for user-authored cases (never overwritten).
+// e.g. "dns/record_a/nios_resources.tfvars" -> "dns/record_a/custom_nios_resources.tfvars".
 func customSibling(fileRelPath string) string {
 	i := strings.LastIndex(fileRelPath, "/")
 	if i < 0 {
@@ -315,9 +263,7 @@ func customSibling(fileRelPath string) string {
 	return fileRelPath[:i+1] + "custom_" + fileRelPath[i+1:]
 }
 
-// loadCustomResourceCases loads resource cases from the sibling custom_ file if
-// present. A missing file, or a file containing only comments (a skeleton with
-// no `case` blocks), yields no cases and no error.
+// loadCustomResourceCases loads cases from the custom_ sibling file; returns nil if absent or empty.
 func loadCustomResourceCases(fileRelPath string) ([]*ResourceCase, error) {
 	full := GetTestdataPath(customSibling(fileRelPath))
 	if _, err := os.Stat(full); err != nil {
@@ -333,10 +279,8 @@ func loadCustomResourceCases(fileRelPath string) ([]*ResourceCase, error) {
 	return cases, nil
 }
 
-// loadResourceCases parses a merged tfvars file into its constituent resource
-// cases. Each case is a labelled `case "<name>" { ... }` block; the label
-// becomes the case (subtest) name. Cases are returned sorted by name for a
-// deterministic subtest order.
+// loadResourceCases parses `case "<name>" { ... }` blocks from a tfvars file,
+// sorted by name for deterministic subtest ordering.
 func loadResourceCases(path string) ([]*ResourceCase, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -376,8 +320,7 @@ func loadResourceCases(path string) ([]*ResourceCase, error) {
 	return cases, nil
 }
 
-// parseResourceCaseBody decodes a single `case` block body into a ResourceCase
-// (the Name is set by the caller from the block label).
+// parseResourceCaseBody decodes a `case` block body into a ResourceCase (Name set by caller).
 func parseResourceCaseBody(body hcl.Body, src []byte) (*ResourceCase, error) {
 	content, _, diags := body.PartialContent(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
@@ -502,11 +445,7 @@ func parseCaseStep(body hcl.Body, src []byte) (CaseStep, error) {
 	return st, nil
 }
 
-// parseCaseBlock parses a config block (common/nios/uddi) into a value map.
-// Literal values are reduced to Go values; non-literal expressions (references
-// to other resources, e.g. ${infoblox_zone_auth.prereq.nios.fqdn}, or
-// depends_on) are preserved verbatim as RawExpr so Terraform resolves them at
-// apply time.
+// parseCaseBlock parses a common/nios/uddi block into a value map; non-literal expressions are kept as RawExpr.
 func parseCaseBlock(body hcl.Body, src []byte) map[string]any {
 	result := make(map[string]any)
 	attrs, _ := body.JustAttributes()

--- a/internal/acctest/cases.go
+++ b/internal/acctest/cases.go
@@ -15,6 +15,37 @@ import (
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/core"
 )
 
+// # Acceptance test infrastructure – verification flow
+//
+// Test cases for every object are generated from the legacy hand-written tests
+// and stored as HCL `case "<name>" { ... }` blocks in the testdata directory:
+//
+//	testdata/<pkg>/<object>/<backend>_resources.tfvars   – resource cases
+//	testdata/<pkg>/<object>/<backend>_datasources.tfvars – data source cases
+//	testdata/<pkg>/<object>/<backend>_lists.tfvars       – list/query cases
+//
+// Each file carries the field values that were exercised in the original test.
+// At runtime the framework reads those values, builds Terraform HCL on the fly,
+// applies it against a live backend, and then verifies the API round-tripped the
+// values correctly. Verification strategy per test type:
+//
+//   - Resource (RunResourceCases / runResourceCase):
+//     step.Checks (key → literal string) → resource.TestCheckResourceAttr
+//     One check per scalar field declared in the case.
+//
+//   - Datasource (RunDataSourceCases / runDataSourceCase):
+//     (a) step config scalar fields → resource.TestCheckResourceAttrPair
+//         asserts data.results.0.<path> == resource.<path> for each field.
+//     (b) PairChecks (extracted from legacy testAccCheck*AttrPair helpers) →
+//         additional resource.TestCheckResourceAttrPair for fields not in the
+//         step config (e.g. fields set by the server, like absolute_name_spec).
+//
+//   - List (RunListCases / runListCase):
+//     Step 1 creates the resource; step 2 runs a list/query and asserts:
+//     (a) querycheck.ExpectLength[AtLeast] – correct number of results.
+//     (b) querycheck.ExpectResourceKnownValues – every scalar literal field
+//         from the create step appears with the same value in the query result.
+
 // ExtractNIOSRef strips the leading object-type segment from a full NIOS _ref
 // (e.g. "record:a/ZG5z..." -> "ZG5z..."). Acceptance check helpers that call
 // the raw NIOS SDK must use this, since the SDK re-applies the type prefix.
@@ -122,6 +153,8 @@ func runResourceCase(t *testing.T, resourceType string, rc *ResourceCase, checks
 		if rc.Disappears && checks.Disappears != nil {
 			checkFuncs = append(checkFuncs, checks.Disappears(resourceAddr))
 		}
+		// Values come from step.Checks, populated at generation time from the
+		// legacy test's resource.TestCheckResourceAttr calls.
 		for attr, expected := range st.Checks {
 			checkFuncs = append(checkFuncs, resource.TestCheckResourceAttr(resourceAddr, attr, expected))
 		}

--- a/internal/acctest/cases_datasource.go
+++ b/internal/acctest/cases_datasource.go
@@ -180,15 +180,22 @@ func (dc *DataSourceCase) materialize() {
 		return v
 	}
 
+	substitute := func(s string) string {
+		for _, ph := range placeholderPattern.FindAllString(s, -1) {
+			s = strings.ReplaceAll(s, ph, value(ph))
+		}
+		return s
+	}
+
 	var replace func(v any) any
 	replace = func(v any) any {
 		switch t := v.(type) {
+		case RawExpr:
+			// A raw HCL expression can still embed placeholders (see the RawExpr
+			// handling in ResourceCase.materialize).
+			return RawExpr(substitute(string(t)))
 		case string:
-			s := t
-			for _, ph := range placeholderPattern.FindAllString(s, -1) {
-				s = strings.ReplaceAll(s, ph, value(ph))
-			}
-			return s
+			return substitute(t)
 		case map[string]any:
 			for k, vv := range t {
 				t[k] = replace(vv)

--- a/internal/acctest/cases_datasource.go
+++ b/internal/acctest/cases_datasource.go
@@ -13,11 +13,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// DataSourceCase is a per-test-case data source acceptance configuration,
-// generated from the legacy provider's hand-written data source acceptance
-// tests. Each case maps 1:1 to a legacy TestAcc<Object>DataSource_<Case>
-// function and is stored as a labelled `case "<name>" { ... }` block in the
-// merged testdata/<package>/<object>/<backend>_datasources.tfvars file.
+// DataSourceCase is the per-subtest configuration for a data source acceptance test.
+// Each case maps to a `case "<name>" { ... }` block in <backend>_datasources.tfvars.
 type DataSourceCase struct {
 	Name             string
 	Backend          string
@@ -28,16 +25,12 @@ type DataSourceCase struct {
 	Filters          map[string]string // filter key -> resource attribute path (e.g. "name" -> "nios.name")
 	FilterOrder      []string          // filter keys in deterministic order
 	Step             CaseStep
-	// PairChecks lists backend-prefixed field paths (e.g. "nios.comment") to verify
-	// via TestCheckResourceAttrPair in addition to the scalar fields in Step.
+	// PairChecks lists extra backend-prefixed paths (e.g. "nios.comment") for TestCheckResourceAttrPair.
 	PairChecks []string
 }
 
-// RunDataSourceCases loads every `case "<name>" { ... }` block from the merged
-// tfvars file at testdata/<fileRelPath> and runs each as an independent
-// subtest. Each case provisions the resource described by its step, queries the
-// data source using the case's filter, and asserts the data source returns the
-// same values as the created resource.
+// RunDataSourceCases loads all `case` blocks from testdata/<fileRelPath> and runs each as a subtest,
+// provisioning the resource and asserting the data source returns matching attribute values.
 func RunDataSourceCases(t *testing.T, dsType, resourceType, fileRelPath string, checksByBackend map[string]CheckFuncs) {
 	path := GetTestdataPath(fileRelPath)
 	cases, err := loadDataSourceCases(path)
@@ -45,8 +38,7 @@ func RunDataSourceCases(t *testing.T, dsType, resourceType, fileRelPath string, 
 		cases = nil
 	}
 
-	// Append user-authored custom cases from the sibling custom_<file> so custom
-	// scenarios written by users run automatically alongside the generated ones.
+	// Also run custom cases from the sibling custom_<file>.
 	customCases, mErr := loadCustomDataSourceCases(fileRelPath)
 	if mErr != nil {
 		t.Fatalf("failed to load custom data source cases for %s: %v", fileRelPath, mErr)
@@ -95,11 +87,6 @@ func runDataSourceCase(t *testing.T, dsType, resourceType string, dc *DataSource
 		checkFuncs = append(checkFuncs, checks.Exists(resourceAddr))
 	}
 	checkFuncs = append(checkFuncs, resource.TestCheckResourceAttrSet(dsAddr, "results.0.id"))
-	// dataSourcePairChecks generates TestCheckResourceAttrPair assertions:
-	//   (a) one per scalar field in dc.Step (derived from the case's step config), and
-	//   (b) one per path in dc.PairChecks, which are extracted at generation time from
-	//       the legacy testAccCheck*AttrPair helpers (handles server-set fields like
-	//       absolute_name_spec that aren't in the tfvars step block).
 	checkFuncs = append(checkFuncs, dataSourcePairChecks(dsAddr, resourceAddr, dc)...)
 
 	tc := resource.TestCase{
@@ -116,8 +103,7 @@ func runDataSourceCase(t *testing.T, dsType, resourceType string, dc *DataSource
 	resource.Test(t, tc)
 }
 
-// buildDataSourceBlock renders the data source HCL with the case's filter,
-// whose values reference attributes of the resource created in the same config.
+// buildDataSourceBlock renders the data source HCL block with filter values referencing the test resource.
 func buildDataSourceBlock(dsType, resourceType string, dc *DataSourceCase) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("data %q \"test\" {\n", dsType))
@@ -131,8 +117,7 @@ func buildDataSourceBlock(dsType, resourceType string, dc *DataSourceCase) strin
 	return sb.String()
 }
 
-// dataSourcePairChecks asserts that each scalar field configured on the
-// resource is returned identically by the data source at results.0.<path>.
+// dataSourcePairChecks returns TestCheckResourceAttrPair checks for all scalar fields in the step config.
 func dataSourcePairChecks(dsAddr, resourceAddr string, dc *DataSourceCase) []resource.TestCheckFunc {
 	var checks []resource.TestCheckFunc
 
@@ -160,13 +145,11 @@ func dataSourcePairChecks(dsAddr, resourceAddr string, dc *DataSourceCase) []res
 		add("uddi", dc.Step.UDDI)
 	}
 
-	// Collect paths already covered by the step-config pair checks above so we
-	// don't emit duplicates from PairChecks.
+	// Track paths already covered above to avoid duplicates from PairChecks.
 	covered := make(map[string]bool, len(checks))
 	for _, fn := range checks {
-		_ = fn // not inspectable; track by re-deriving covered paths below
+		_ = fn // not inspectable; re-derive covered paths below
 	}
-	// Re-derive covered paths from step config.
 	addCovered := func(prefix string, m map[string]any) {
 		for k, v := range m {
 			if !isScalarValue(v) {
@@ -201,8 +184,7 @@ func dataSourcePairChecks(dsAddr, resourceAddr string, dc *DataSourceCase) []res
 	return checks
 }
 
-// isScalarValue reports whether v is a simple scalar (and thus safe to compare
-// with TestCheckResourceAttrPair). Maps, lists and raw expressions are skipped.
+// isScalarValue reports whether v is a scalar safe to use with TestCheckResourceAttrPair.
 func isScalarValue(v any) bool {
 	switch v.(type) {
 	case map[string]any, []any, RawExpr:
@@ -212,9 +194,7 @@ func isScalarValue(v any) bool {
 	}
 }
 
-// materialize replaces placeholders (e.g. {{random}}) with concrete values,
-// keeping each distinct placeholder consistent across the resource config and
-// prerequisites so the data source filter resolves to the created resource.
+// materialize replaces {{placeholder}} tokens with stable values across the step config and prerequisites.
 func (dc *DataSourceCase) materialize() {
 	cache := make(map[string]string)
 
@@ -238,8 +218,7 @@ func (dc *DataSourceCase) materialize() {
 	replace = func(v any) any {
 		switch t := v.(type) {
 		case RawExpr:
-			// A raw HCL expression can still embed placeholders (see the RawExpr
-			// handling in ResourceCase.materialize).
+			// RawExpr values may still contain placeholders; substitute and keep raw.
 			return RawExpr(substitute(string(t)))
 		case string:
 			return substitute(t)
@@ -272,13 +251,7 @@ func (dc *DataSourceCase) materialize() {
 	}
 }
 
-// loadDataSourceCases parses a merged tfvars file into its constituent data
-// source cases. Each case is a labelled `case "<name>" { ... }` block; the
-// label becomes the case (subtest) name. Cases are returned sorted by name for
-// a deterministic subtest order.
-// loadCustomDataSourceCases loads data source cases from the sibling custom_
-// file if present. A missing file, or a file containing only comments (a
-// skeleton with no `case` blocks), yields no cases and no error.
+// loadCustomDataSourceCases loads cases from the custom_ sibling file; returns nil if absent or empty.
 func loadCustomDataSourceCases(fileRelPath string) ([]*DataSourceCase, error) {
 	full := GetTestdataPath(customSibling(fileRelPath))
 	if _, err := os.Stat(full); err != nil {
@@ -294,6 +267,8 @@ func loadCustomDataSourceCases(fileRelPath string) ([]*DataSourceCase, error) {
 	return cases, nil
 }
 
+// loadDataSourceCases parses `case "<name>" { ... }` blocks from a data source tfvars file,
+// sorted by name for deterministic subtest ordering.
 func loadDataSourceCases(path string) ([]*DataSourceCase, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -333,8 +308,7 @@ func loadDataSourceCases(path string) ([]*DataSourceCase, error) {
 	return cases, nil
 }
 
-// parseDataSourceCaseBody decodes a single `case` block body into a
-// DataSourceCase (the Name is set by the caller from the block label).
+// parseDataSourceCaseBody decodes a `case` block body into a DataSourceCase (Name set by caller).
 func parseDataSourceCaseBody(body hcl.Body, src []byte) (*DataSourceCase, error) {
 	content, _, diags := body.PartialContent(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{

--- a/internal/acctest/cases_datasource.go
+++ b/internal/acctest/cases_datasource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // DataSourceCase is a per-test-case data source acceptance configuration,
@@ -27,6 +28,9 @@ type DataSourceCase struct {
 	Filters          map[string]string // filter key -> resource attribute path (e.g. "name" -> "nios.name")
 	FilterOrder      []string          // filter keys in deterministic order
 	Step             CaseStep
+	// PairChecks lists backend-prefixed field paths (e.g. "nios.comment") to verify
+	// via TestCheckResourceAttrPair in addition to the scalar fields in Step.
+	PairChecks []string
 }
 
 // RunDataSourceCases loads every `case "<name>" { ... }` block from the merged
@@ -91,6 +95,11 @@ func runDataSourceCase(t *testing.T, dsType, resourceType string, dc *DataSource
 		checkFuncs = append(checkFuncs, checks.Exists(resourceAddr))
 	}
 	checkFuncs = append(checkFuncs, resource.TestCheckResourceAttrSet(dsAddr, "results.0.id"))
+	// dataSourcePairChecks generates TestCheckResourceAttrPair assertions:
+	//   (a) one per scalar field in dc.Step (derived from the case's step config), and
+	//   (b) one per path in dc.PairChecks, which are extracted at generation time from
+	//       the legacy testAccCheck*AttrPair helpers (handles server-set fields like
+	//       absolute_name_spec that aren't in the tfvars step block).
 	checkFuncs = append(checkFuncs, dataSourcePairChecks(dsAddr, resourceAddr, dc)...)
 
 	tc := resource.TestCase{
@@ -149,6 +158,44 @@ func dataSourcePairChecks(dsAddr, resourceAddr string, dc *DataSourceCase) []res
 		add("nios", dc.Step.NIOS)
 	case "uddi":
 		add("uddi", dc.Step.UDDI)
+	}
+
+	// Collect paths already covered by the step-config pair checks above so we
+	// don't emit duplicates from PairChecks.
+	covered := make(map[string]bool, len(checks))
+	for _, fn := range checks {
+		_ = fn // not inspectable; track by re-deriving covered paths below
+	}
+	// Re-derive covered paths from step config.
+	addCovered := func(prefix string, m map[string]any) {
+		for k, v := range m {
+			if !isScalarValue(v) {
+				continue
+			}
+			path := k
+			if prefix != "" {
+				path = prefix + "." + k
+			}
+			covered[path] = true
+		}
+	}
+	addCovered("", dc.Step.Common)
+	switch dc.Backend {
+	case "nios":
+		addCovered("nios", dc.Step.NIOS)
+	case "uddi":
+		addCovered("uddi", dc.Step.UDDI)
+	}
+
+	for _, path := range dc.PairChecks {
+		if covered[path] {
+			continue
+		}
+		checks = append(checks, resource.TestCheckResourceAttrPair(
+			dsAddr, "results.0."+path,
+			resourceAddr, path,
+		))
+		covered[path] = true
 	}
 
 	return checks
@@ -295,6 +342,7 @@ func parseDataSourceCaseBody(body hcl.Body, src []byte) (*DataSourceCase, error)
 			{Name: "skip"},
 			{Name: "skip_reason"},
 			{Name: "prerequisites_hcl"},
+			{Name: "pair_checks"},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "filter"},
@@ -321,6 +369,18 @@ func parseDataSourceCaseBody(body hcl.Body, src []byte) (*DataSourceCase, error)
 	if attr, ok := content.Attributes["prerequisites_hcl"]; ok {
 		val, _ := attr.Expr.Value(nil)
 		dc.PrerequisitesHCL = val.AsString()
+	}
+	if attr, ok := content.Attributes["pair_checks"]; ok {
+		val, _ := attr.Expr.Value(nil)
+		if val.CanIterateElements() {
+			it := val.ElementIterator()
+			for it.Next() {
+				_, v := it.Element()
+				if v.Type() == cty.String {
+					dc.PairChecks = append(dc.PairChecks, v.AsString())
+				}
+			}
+		}
 	}
 
 	for _, block := range content.Blocks {

--- a/internal/acctest/cases_list.go
+++ b/internal/acctest/cases_list.go
@@ -18,11 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
-// ListCase is a per-test-case list/query acceptance configuration, generated
-// from the legacy provider's hand-written list acceptance tests. Each case maps
-// 1:1 to a legacy TestAcc<Object>List_<Case> function and is stored as a
-// labelled `case "<name>" { ... }` block in the merged
-// testdata/<package>/<object>/<backend>_lists.tfvars file.
+// ListCase is the per-subtest configuration for a list query acceptance test.
+// Each case maps to a `case "<name>" { ... }` block in <backend>_lists.tfvars.
 type ListCase struct {
 	Name         string
 	Backend      string
@@ -33,16 +30,12 @@ type ListCase struct {
 	Filters      map[string]string // filter key -> resource attribute path (e.g. "network" -> "nios.network")
 	FilterOrder  []string          // filter keys in deterministic order
 	Step         CaseStep          // resource-create step
-	// PrerequisitesHCL holds resources the create step references (e.g. the auth
-	// zone a record lives in). It is prepended to both steps' configs, since the
-	// query step must keep the created resource alive.
+	// PrerequisitesHCL is prepended to both the create and query steps so the resource stays alive.
 	PrerequisitesHCL string
 }
 
-// RunListCases loads every `case "<name>" { ... }` block from the merged
-// tfvars file at testdata/<fileRelPath> and runs each as an independent
-// two-step subtest: step 1 creates the resource, step 2 runs a list query
-// and asserts at least one result is returned.
+// RunListCases loads all `case` blocks from testdata/<fileRelPath> and runs each as a two-step subtest:
+// step 1 creates the resource, step 2 issues a list query and asserts at least one result is returned.
 func RunListCases(t *testing.T, resourceType, fileRelPath string, checksByBackend map[string]CheckFuncs) {
 	t.Helper()
 	path := GetTestdataPath(fileRelPath)
@@ -91,13 +84,6 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 
 	resourceAddr := resourceType + ".test"
 
-	// buildQueryChecks assembles two kinds of assertions for step 2:
-	//   (a) ExpectLength[AtLeast] – verifies the filter returned exactly the right
-	//       number of objects (1 for filtered, ≥1 for list-all).
-	//   (b) ExpectResourceKnownValues – verifies every scalar literal from the
-	//       create step appears with the same value in the query result, so we
-	//       know the list API round-trips all written fields, not just that some
-	//       object was returned.
 	queryChecks := buildQueryChecks(resourceAddr, lc)
 
 	tc := resource.TestCase{
@@ -127,12 +113,7 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 }
 
 // buildQueryChecks assembles QueryResultChecks for the list query step.
-// Filtered cases assert an exact count of 1 and validate each filter attribute
-// on the returned resource object. List-all cases (empty FilterType) only
-// assert that at least one result is present.
-// In both cases, all scalar literal fields from the create step are also
-// verified via ExpectResourceKnownValues so the query result reflects what was
-// written — not just that a result was returned.
+// Filtered cases assert an exact count of 1; list-all cases assert at least one result.
 func buildQueryChecks(resourceAddr string, lc *ListCase) []querycheck.QueryResultCheck {
 	var checks []querycheck.QueryResultCheck
 
@@ -142,10 +123,7 @@ func buildQueryChecks(resourceAddr string, lc *ListCase) []querycheck.QueryResul
 		checks = append(checks, querycheck.ExpectLength(resourceAddr, 1))
 	}
 
-	// Collect KnownValueChecks from all resolvable scalar step fields.
-	// For "filters" mode, filter-field values are always included; for all
-	// modes we additionally include non-filter scalar step fields so that
-	// fields like ipv4addr and view are verified in the query result.
+	// Include all resolvable scalar step fields (e.g. ipv4addr, view) in the known-value checks.
 	knownChecks := buildStepKnownValueChecks(lc)
 	if len(knownChecks) > 0 {
 		checks = append(checks, querycheck.ExpectResourceKnownValues(
@@ -156,10 +134,8 @@ func buildQueryChecks(resourceAddr string, lc *ListCase) []querycheck.QueryResul
 	return checks
 }
 
-// buildStepKnownValueChecks collects all resolvable scalar fields from the
-// create step and returns them as KnownValueChecks. Fields whose values are
-// resource references (RawExpr that cannot be resolved to a literal) are
-// skipped so only stable literal values are verified.
+// buildStepKnownValueChecks returns KnownValueChecks for all resolvable scalar fields in the create step.
+// Fields that are resource references (RawExpr) are skipped; only literal values are verified.
 func buildStepKnownValueChecks(lc *ListCase) []querycheck.KnownValueCheck {
 	var knownChecks []querycheck.KnownValueCheck
 	seen := make(map[string]bool)
@@ -203,11 +179,8 @@ func buildStepKnownValueChecks(lc *ListCase) []querycheck.KnownValueCheck {
 	return knownChecks
 }
 
-// buildListBlock renders the `list "<resourceType>" "test" { ... }` HCL for a
-// list query step. An empty FilterType means list-all (limit only, no config
-// block); otherwise a config block with filters/extattrfilters is emitted.
-// Filter values are resolved from the materialized step config (not resource
-// references) because the Query step config contains only the list block.
+// buildListBlock renders the `list "<resourceType>" "test" { ... }` HCL for the query step.
+// An empty FilterType produces a list-all block; otherwise a filtered config block is emitted.
 func buildListBlock(resourceType string, lc *ListCase) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("list %q \"test\" {\n", resourceType))
@@ -235,9 +208,7 @@ func buildListBlock(resourceType string, lc *ListCase) string {
 	return sb.String()
 }
 
-// resolveStepValue looks up the materialized value for a resource attribute
-// reference path (e.g. "nios.network", "nios.ext_attrs.Site") in the case's
-// create step.
+// resolveStepValue returns the materialized value for a step attribute ref path (e.g. "nios.network").
 func resolveStepValue(refPath string, lc *ListCase) string {
 	parts := strings.SplitN(refPath, ".", 2)
 	if len(parts) < 2 {
@@ -272,12 +243,9 @@ func resolveStepValue(refPath string, lc *ListCase) string {
 	return stepScalarValue(nested[attrParts[1]], lc.PrerequisitesHCL)
 }
 
-// stepScalarValue renders a single step-config value as the concrete string a
-// filter needs. String literals pass through; expressions kept as RawExpr (e.g.
-// "{{random}}.${infoblox_zone_auth.test.nios.fqdn}") are resolved against the
-// prerequisites HCL, since a query step's config holds only the list block and
-// so cannot reference the created resource. Non-string scalars are not usable as
-// filter values and yield "".
+// stepScalarValue renders a step value as a filter string.
+// String literals pass through; RawExpr is resolved against prereqHCL since the query step holds only the list block.
+// Non-string scalars yield "".
 func stepScalarValue(raw any, prereqHCL string) string {
 	switch v := raw.(type) {
 	case string:
@@ -289,16 +257,11 @@ func stepScalarValue(raw any, prereqHCL string) string {
 	}
 }
 
-// prereqRefPattern matches an attribute reference inside a raw HCL expression,
-// either interpolated ("${infoblox_zone_auth.test.nios.fqdn}") or bare
-// (infoblox_zone_auth.test.nios.fqdn).
+// prereqRefPattern matches interpolated ("${...}") or bare attribute references in HCL expressions.
 var prereqRefPattern = regexp.MustCompile(`\$\{\s*([a-zA-Z_][\w-]*(?:\.[\w-]+)+)\s*\}|([a-zA-Z_][\w-]*(?:\.[\w-]+)+)`)
 
-// resolveRawExpr reduces a raw HCL expression to a literal by substituting every
-// reference to a prerequisite resource attribute. It returns "" when the
-// expression references something the prerequisites do not define as a literal
-// (e.g. a computed attribute such as a zone's view), so the caller skips that
-// filter rather than emitting an unresolved reference.
+// resolveRawExpr reduces a raw HCL expression to a literal by substituting prerequisite attribute refs.
+// Returns "" if any referenced attribute is not a literal in the prerequisites.
 func resolveRawExpr(raw, prereqHCL string) string {
 	expr := strings.TrimSpace(raw)
 	if len(expr) >= 2 && strings.HasPrefix(expr, `"`) && strings.HasSuffix(expr, `"`) {
@@ -325,10 +288,8 @@ func resolveRawExpr(raw, prereqHCL string) string {
 	return expr
 }
 
-// prereqAttrLiterals maps each literal attribute of the materialized
-// prerequisites HCL to the reference path Terraform uses for it, e.g.
-// "infoblox_zone_auth.test.nios.fqdn" -> "tf-acc-test-abc.com". Computed and
-// non-literal attributes are absent.
+// prereqAttrLiterals extracts literal attribute values from materialized prerequisites HCL,
+// keyed by Terraform reference path (e.g. "infoblox_zone_auth.test.nios.fqdn").
 func prereqAttrLiterals(prereqHCL string) map[string]string {
 	literals := make(map[string]string)
 	if strings.TrimSpace(prereqHCL) == "" {
@@ -359,9 +320,7 @@ func prereqAttrLiterals(prereqHCL string) map[string]string {
 	return literals
 }
 
-// flattenLiteral records scalars at their full reference path, recursing into
-// nested objects so config blocks like `nios = { fqdn = "..." }` are reachable
-// as "<type>.<name>.nios.fqdn". Lists and nulls have no usable reference path.
+// flattenLiteral recursively records scalar values at their full reference path, skipping lists and nulls.
 func flattenLiteral(out map[string]string, path string, v any) {
 	switch t := v.(type) {
 	case nil, []any:
@@ -375,8 +334,7 @@ func flattenLiteral(out map[string]string, path string, v any) {
 	}
 }
 
-// refPathToTFJSONPath converts a resource attribute ref path like "nios.network"
-// or "nios.ext_attrs.Site" into a tfjsonpath.Path for use in KnownValueChecks.
+// refPathToTFJSONPath converts a ref path like "nios.ext_attrs.Site" into a tfjsonpath.Path.
 func refPathToTFJSONPath(refPath string) tfjsonpath.Path {
 	parts := strings.Split(refPath, ".")
 	p := tfjsonpath.New(parts[0])
@@ -386,8 +344,7 @@ func refPathToTFJSONPath(refPath string) tfjsonpath.Path {
 	return p
 }
 
-// materialize replaces {{placeholder}} tokens with concrete runtime values,
-// keeping each distinct placeholder consistent across the step config.
+// materialize replaces {{placeholder}} tokens with stable values across the step config and prerequisites.
 func (lc *ListCase) materialize() {
 	cache := make(map[string]string)
 
@@ -411,8 +368,7 @@ func (lc *ListCase) materialize() {
 	replace = func(v any) any {
 		switch t := v.(type) {
 		case RawExpr:
-			// A raw HCL expression can still embed placeholders (see the RawExpr
-			// handling in ResourceCase.materialize).
+			// RawExpr values may still contain placeholders; substitute and keep raw.
 			return RawExpr(substitute(string(t)))
 		case string:
 			return substitute(t)
@@ -526,9 +482,7 @@ func parseListCaseBody(body hcl.Body, src []byte) (*ListCase, error) {
 		if block.Type != "step" {
 			continue
 		}
-		// Peek at query/display attributes and the optional filter block inside
-		// this step. PartialContent only consumes what matches — remaining
-		// content is still available for parseCaseStep on the same body.
+		// Peek at query/filter metadata; PartialContent leaves remaining content available for parseCaseStep.
 		stepMeta, _, _ := block.Body.PartialContent(&hcl.BodySchema{
 			Attributes: []hcl.AttributeSchema{
 				{Name: "query"},

--- a/internal/acctest/cases_list.go
+++ b/internal/acctest/cases_list.go
@@ -3,6 +3,7 @@ package acctest
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -32,6 +33,10 @@ type ListCase struct {
 	Filters      map[string]string // filter key -> resource attribute path (e.g. "network" -> "nios.network")
 	FilterOrder  []string          // filter keys in deterministic order
 	Step         CaseStep          // resource-create step
+	// PrerequisitesHCL holds resources the create step references (e.g. the auth
+	// zone a record lives in). It is prepended to both steps' configs, since the
+	// query step must keep the created resource alive.
+	PrerequisitesHCL string
 }
 
 // RunListCases loads every `case "<name>" { ... }` block from the merged
@@ -79,8 +84,10 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 	resourceHCL := buildCaseHCL(resourceType, "test", lc.Backend, lc.Step)
 	listHCL := buildListBlock(resourceType, lc)
 
-	t.Logf("Case %q create HCL:\n%s", lc.Name, providerConfig+"\n"+resourceHCL)
-	t.Logf("Case %q list HCL:\n%s", lc.Name, providerConfig+"\n"+listHCL)
+	createConfig := providerConfig + "\n" + lc.PrerequisitesHCL + "\n" + resourceHCL
+
+	t.Logf("Case %q create HCL:\n%s", lc.Name, createConfig)
+	t.Logf("Case %q list HCL:\n%s", lc.Name, listHCL)
 
 	resourceAddr := resourceType + ".test"
 
@@ -90,7 +97,7 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + "\n" + resourceHCL,
+				Config: createConfig,
 				Check:  resource.ComposeTestCheckFunc(checks.Exists(resourceAddr)),
 			},
 			{
@@ -134,7 +141,7 @@ func buildQueryChecks(resourceAddr string, lc *ListCase) []querycheck.QueryResul
 		var knownChecks []querycheck.KnownValueCheck
 		for _, key := range lc.FilterOrder {
 			refPath := lc.Filters[key]
-			val := resolveStepValue(refPath, lc.Step)
+			val := resolveStepValue(refPath, lc)
 			if val == "" {
 				continue
 			}
@@ -172,7 +179,7 @@ func buildListBlock(resourceType string, lc *ListCase) string {
 		sb.WriteString(fmt.Sprintf("    %s = {\n", lc.FilterType))
 		for _, key := range lc.FilterOrder {
 			refPath := lc.Filters[key]
-			val := resolveStepValue(refPath, lc.Step)
+			val := resolveStepValue(refPath, lc)
 			if val != "" {
 				sb.WriteString(fmt.Sprintf("      %s = %q\n", key, val))
 			}
@@ -186,8 +193,9 @@ func buildListBlock(resourceType string, lc *ListCase) string {
 }
 
 // resolveStepValue looks up the materialized value for a resource attribute
-// reference path (e.g. "nios.network", "nios.ext_attrs.Site") in the step.
-func resolveStepValue(refPath string, step CaseStep) string {
+// reference path (e.g. "nios.network", "nios.ext_attrs.Site") in the case's
+// create step.
+func resolveStepValue(refPath string, lc *ListCase) string {
 	parts := strings.SplitN(refPath, ".", 2)
 	if len(parts) < 2 {
 		return ""
@@ -197,11 +205,11 @@ func resolveStepValue(refPath string, step CaseStep) string {
 	var m map[string]any
 	switch section {
 	case "nios":
-		m = step.NIOS
+		m = lc.Step.NIOS
 	case "uddi":
-		m = step.UDDI
+		m = lc.Step.UDDI
 	default:
-		m = step.Common
+		m = lc.Step.Common
 	}
 
 	// Handle simple path like "network" and nested like "ext_attrs.Site"
@@ -211,20 +219,117 @@ func resolveStepValue(refPath string, step CaseStep) string {
 		return ""
 	}
 	if len(attrParts) == 1 {
-		if s, ok := raw.(string); ok {
-			return s
-		}
-		return ""
+		return stepScalarValue(raw, lc.PrerequisitesHCL)
 	}
 	// Nested map (e.g. ext_attrs.Site)
 	nested, ok := raw.(map[string]any)
 	if !ok {
 		return ""
 	}
-	if s, ok := nested[attrParts[1]].(string); ok {
-		return s
+	return stepScalarValue(nested[attrParts[1]], lc.PrerequisitesHCL)
+}
+
+// stepScalarValue renders a single step-config value as the concrete string a
+// filter needs. String literals pass through; expressions kept as RawExpr (e.g.
+// "{{random}}.${infoblox_zone_auth.test.nios.fqdn}") are resolved against the
+// prerequisites HCL, since a query step's config holds only the list block and
+// so cannot reference the created resource. Non-string scalars are not usable as
+// filter values and yield "".
+func stepScalarValue(raw any, prereqHCL string) string {
+	switch v := raw.(type) {
+	case string:
+		return v
+	case RawExpr:
+		return resolveRawExpr(string(v), prereqHCL)
+	default:
+		return ""
 	}
-	return ""
+}
+
+// prereqRefPattern matches an attribute reference inside a raw HCL expression,
+// either interpolated ("${infoblox_zone_auth.test.nios.fqdn}") or bare
+// (infoblox_zone_auth.test.nios.fqdn).
+var prereqRefPattern = regexp.MustCompile(`\$\{\s*([a-zA-Z_][\w-]*(?:\.[\w-]+)+)\s*\}|([a-zA-Z_][\w-]*(?:\.[\w-]+)+)`)
+
+// resolveRawExpr reduces a raw HCL expression to a literal by substituting every
+// reference to a prerequisite resource attribute. It returns "" when the
+// expression references something the prerequisites do not define as a literal
+// (e.g. a computed attribute such as a zone's view), so the caller skips that
+// filter rather than emitting an unresolved reference.
+func resolveRawExpr(raw, prereqHCL string) string {
+	expr := strings.TrimSpace(raw)
+	if len(expr) >= 2 && strings.HasPrefix(expr, `"`) && strings.HasSuffix(expr, `"`) {
+		expr = expr[1 : len(expr)-1]
+	}
+
+	matches := prereqRefPattern.FindAllStringSubmatch(expr, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+
+	literals := prereqAttrLiterals(prereqHCL)
+	for _, m := range matches {
+		ref := m[1]
+		if ref == "" {
+			ref = m[2]
+		}
+		val, ok := literals[ref]
+		if !ok {
+			return ""
+		}
+		expr = strings.ReplaceAll(expr, m[0], val)
+	}
+	return expr
+}
+
+// prereqAttrLiterals maps each literal attribute of the materialized
+// prerequisites HCL to the reference path Terraform uses for it, e.g.
+// "infoblox_zone_auth.test.nios.fqdn" -> "tf-acc-test-abc.com". Computed and
+// non-literal attributes are absent.
+func prereqAttrLiterals(prereqHCL string) map[string]string {
+	literals := make(map[string]string)
+	if strings.TrimSpace(prereqHCL) == "" {
+		return literals
+	}
+
+	file, diags := hclparse.NewParser().ParseHCL([]byte(prereqHCL), "prerequisites.hcl")
+	if diags.HasErrors() {
+		return literals
+	}
+	content, _, _ := file.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "resource", LabelNames: []string{"type", "name"}},
+		},
+	})
+
+	for _, block := range content.Blocks {
+		prefix := block.Labels[0] + "." + block.Labels[1]
+		attrs, _ := block.Body.JustAttributes()
+		for name, attr := range attrs {
+			val, valDiags := attr.Expr.Value(nil)
+			if valDiags.HasErrors() || !val.IsWhollyKnown() {
+				continue
+			}
+			flattenLiteral(literals, prefix+"."+name, ctyToGo(val))
+		}
+	}
+	return literals
+}
+
+// flattenLiteral records scalars at their full reference path, recursing into
+// nested objects so config blocks like `nios = { fqdn = "..." }` are reachable
+// as "<type>.<name>.nios.fqdn". Lists and nulls have no usable reference path.
+func flattenLiteral(out map[string]string, path string, v any) {
+	switch t := v.(type) {
+	case nil, []any:
+		return
+	case map[string]any:
+		for k, vv := range t {
+			flattenLiteral(out, path+"."+k, vv)
+		}
+	default:
+		out[path] = fmt.Sprintf("%v", t)
+	}
 }
 
 // refPathToTFJSONPath converts a resource attribute ref path like "nios.network"
@@ -252,15 +357,22 @@ func (lc *ListCase) materialize() {
 		return v
 	}
 
+	substitute := func(s string) string {
+		for _, ph := range placeholderPattern.FindAllString(s, -1) {
+			s = strings.ReplaceAll(s, ph, value(ph))
+		}
+		return s
+	}
+
 	var replace func(v any) any
 	replace = func(v any) any {
 		switch t := v.(type) {
+		case RawExpr:
+			// A raw HCL expression can still embed placeholders (see the RawExpr
+			// handling in ResourceCase.materialize).
+			return RawExpr(substitute(string(t)))
 		case string:
-			s := t
-			for _, ph := range placeholderPattern.FindAllString(s, -1) {
-				s = strings.ReplaceAll(s, ph, value(ph))
-			}
-			return s
+			return substitute(t)
 		case map[string]any:
 			for k, vv := range t {
 				t[k] = replace(vv)
@@ -275,6 +387,8 @@ func (lc *ListCase) materialize() {
 			return v
 		}
 	}
+
+	lc.PrerequisitesHCL = substitute(lc.PrerequisitesHCL)
 
 	for k, v := range lc.Step.Common {
 		lc.Step.Common[k] = replace(v)
@@ -333,6 +447,7 @@ func parseListCaseBody(body hcl.Body, src []byte) (*ListCase, error) {
 			{Name: "skip"},
 			{Name: "skip_reason"},
 			{Name: "min_tf_version"},
+			{Name: "prerequisites_hcl"},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "step"},
@@ -358,6 +473,10 @@ func parseListCaseBody(body hcl.Body, src []byte) (*ListCase, error) {
 	if attr, ok := content.Attributes["min_tf_version"]; ok {
 		val, _ := attr.Expr.Value(nil)
 		lc.MinTFVersion = val.AsString()
+	}
+	if attr, ok := content.Attributes["prerequisites_hcl"]; ok {
+		val, _ := attr.Expr.Value(nil)
+		lc.PrerequisitesHCL = val.AsString()
 	}
 
 	for _, block := range content.Blocks {

--- a/internal/acctest/cases_list.go
+++ b/internal/acctest/cases_list.go
@@ -91,6 +91,13 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 
 	resourceAddr := resourceType + ".test"
 
+	// buildQueryChecks assembles two kinds of assertions for step 2:
+	//   (a) ExpectLength[AtLeast] – verifies the filter returned exactly the right
+	//       number of objects (1 for filtered, ≥1 for list-all).
+	//   (b) ExpectResourceKnownValues – verifies every scalar literal from the
+	//       create step appears with the same value in the query result, so we
+	//       know the list API round-trips all written fields, not just that some
+	//       object was returned.
 	queryChecks := buildQueryChecks(resourceAddr, lc)
 
 	tc := resource.TestCase{
@@ -123,41 +130,77 @@ func runListCase(t *testing.T, resourceType string, lc *ListCase, checks CheckFu
 // Filtered cases assert an exact count of 1 and validate each filter attribute
 // on the returned resource object. List-all cases (empty FilterType) only
 // assert that at least one result is present.
+// In both cases, all scalar literal fields from the create step are also
+// verified via ExpectResourceKnownValues so the query result reflects what was
+// written — not just that a result was returned.
 func buildQueryChecks(resourceAddr string, lc *ListCase) []querycheck.QueryResultCheck {
+	var checks []querycheck.QueryResultCheck
+
 	if lc.FilterType == "" {
-		return []querycheck.QueryResultCheck{
-			querycheck.ExpectLengthAtLeast(resourceAddr, 1),
-		}
+		checks = append(checks, querycheck.ExpectLengthAtLeast(resourceAddr, 1))
+	} else {
+		checks = append(checks, querycheck.ExpectLength(resourceAddr, 1))
 	}
 
-	checks := []querycheck.QueryResultCheck{
-		querycheck.ExpectLength(resourceAddr, 1),
-	}
-
-	// ExpectResourceKnownValues only works for simple filters (not EA/tag
-	// filters where the attribute path in the query result is structured
-	// differently from regular fields).
-	if lc.FilterType == "filters" {
-		var knownChecks []querycheck.KnownValueCheck
-		for _, key := range lc.FilterOrder {
-			refPath := lc.Filters[key]
-			val := resolveStepValue(refPath, lc)
-			if val == "" {
-				continue
-			}
-			knownChecks = append(knownChecks, querycheck.KnownValueCheck{
-				Path:       refPathToTFJSONPath(refPath),
-				KnownValue: knownvalue.StringExact(val),
-			})
-		}
-		if len(knownChecks) > 0 {
-			checks = append(checks, querycheck.ExpectResourceKnownValues(
-				resourceAddr, nil, knownChecks,
-			))
-		}
+	// Collect KnownValueChecks from all resolvable scalar step fields.
+	// For "filters" mode, filter-field values are always included; for all
+	// modes we additionally include non-filter scalar step fields so that
+	// fields like ipv4addr and view are verified in the query result.
+	knownChecks := buildStepKnownValueChecks(lc)
+	if len(knownChecks) > 0 {
+		checks = append(checks, querycheck.ExpectResourceKnownValues(
+			resourceAddr, nil, knownChecks,
+		))
 	}
 
 	return checks
+}
+
+// buildStepKnownValueChecks collects all resolvable scalar fields from the
+// create step and returns them as KnownValueChecks. Fields whose values are
+// resource references (RawExpr that cannot be resolved to a literal) are
+// skipped so only stable literal values are verified.
+func buildStepKnownValueChecks(lc *ListCase) []querycheck.KnownValueCheck {
+	var knownChecks []querycheck.KnownValueCheck
+	seen := make(map[string]bool)
+
+	addField := func(refPath string) {
+		if seen[refPath] {
+			return
+		}
+		val := resolveStepValue(refPath, lc)
+		if val == "" {
+			return
+		}
+		seen[refPath] = true
+		knownChecks = append(knownChecks, querycheck.KnownValueCheck{
+			Path:       refPathToTFJSONPath(refPath),
+			KnownValue: knownvalue.StringExact(val),
+		})
+	}
+
+	addSection := func(prefix string, m map[string]any) {
+		for k, v := range m {
+			if !isScalarValue(v) {
+				continue
+			}
+			path := k
+			if prefix != "" {
+				path = prefix + "." + k
+			}
+			addField(path)
+		}
+	}
+
+	addSection("", lc.Step.Common)
+	switch lc.Backend {
+	case "nios":
+		addSection("nios", lc.Step.NIOS)
+	case "uddi":
+		addSection("uddi", lc.Step.UDDI)
+	}
+
+	return knownChecks
 }
 
 // buildListBlock renders the `list "<resourceType>" "test" { ... }` HCL for a

--- a/internal/acctest/loader.go
+++ b/internal/acctest/loader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// LoadTfvars loads and parses a tfvars file.
+// LoadTfvars reads and parses the HCL tfvars file at relativePath, substituting all {{placeholder}} tokens.
 func LoadTfvars(relativePath string) (*Tfvars, error) {
 	path := GetTestdataPath(relativePath)
 	data, err := os.ReadFile(path)
@@ -49,7 +49,6 @@ func LoadTfvars(relativePath string) (*Tfvars, error) {
 		return nil, fmt.Errorf("failed to decode tfvars: %s", diags.Error())
 	}
 
-	// Parse top-level attributes
 	if attr, exists := contentBody.Attributes["backend"]; exists {
 		val, _ := attr.Expr.Value(nil)
 		tv.Backend = val.AsString()
@@ -67,7 +66,6 @@ func LoadTfvars(relativePath string) (*Tfvars, error) {
 		tv.DSFilterField = val.AsString()
 	}
 
-	// Parse blocks
 	for _, block := range contentBody.Blocks {
 		switch block.Type {
 		case "common":
@@ -97,8 +95,7 @@ func ctyToGo(val cty.Value) any {
 		return nil
 	}
 	if !val.IsKnown() {
-		// Reference/unknown value (e.g. ${resource.attr}); cannot be reduced to
-		// a literal here. Callers that need the source text handle this earlier.
+		// Unknown/reference values cannot be reduced to a literal; callers handle source text upstream.
 		return nil
 	}
 	switch val.Type() {
@@ -141,8 +138,7 @@ func ctyMapToStringMap(val cty.Value) map[string]string {
 	for it := val.ElementIterator(); it.Next(); {
 		k, v := it.Element()
 		if !k.IsKnown() || !v.IsWhollyKnown() {
-			// Skip dynamic entries (e.g. a check referencing another resource);
-			// they cannot be asserted as a static expected value.
+			// Skip entries referencing another resource; they have no static expected value.
 			continue
 		}
 		result[k.AsString()] = fmt.Sprintf("%v", ctyToGo(v))

--- a/internal/acctest/runner.go
+++ b/internal/acctest/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// runTest runs a test case, using ParallelTest if parallel is true.
 func runTest(t *testing.T, parallel bool, tc resource.TestCase) {
 	if parallel {
 		resource.ParallelTest(t, tc)
@@ -16,7 +15,7 @@ func runTest(t *testing.T, parallel bool, tc resource.TestCase) {
 	}
 }
 
-// RunDataSourceTests runs all tests for a data source based on tfvars.
+// RunDataSourceTests runs filter, ext_attr, and tag-filter data source subtests for the given tfvarsPath.
 func RunDataSourceTests(t *testing.T, dsType, resourceType string, tfvarsPath string, checks CheckFuncs) {
 	tv, err := LoadTfvars(tfvarsPath)
 	if err != nil {
@@ -77,7 +76,6 @@ data %q "test" {
 		checkFuncs = append(checkFuncs, checks.Exists(resourceAddr))
 	}
 
-	// Verify data source returns correct data by comparing with created resource
 	checkFuncs = append(checkFuncs, resource.TestCheckResourceAttrSet(dsAddr, "results.0.id"))
 	checkFuncs = append(checkFuncs, buildDataSourceAttrPairChecks(dsAddr, resourceAddr, tv)...)
 
@@ -116,7 +114,6 @@ data %q "test" {
 		checkFuncs = append(checkFuncs, checks.Exists(resourceAddr))
 	}
 
-	// Verify data source returns correct data by comparing with created resource
 	checkFuncs = append(checkFuncs, resource.TestCheckResourceAttrSet(dsAddr, "results.0.id"))
 	checkFuncs = append(checkFuncs, buildDataSourceAttrPairChecks(dsAddr, resourceAddr, tv)...)
 
@@ -155,7 +152,6 @@ data %q "test" {
 		checkFuncs = append(checkFuncs, checks.Exists(resourceAddr))
 	}
 
-	// Verify data source returns correct data by comparing with created resource
 	checkFuncs = append(checkFuncs, resource.TestCheckResourceAttrSet(dsAddr, "results.0.id"))
 	checkFuncs = append(checkFuncs, buildDataSourceAttrPairChecks(dsAddr, resourceAddr, tv)...)
 
@@ -169,12 +165,10 @@ data %q "test" {
 	})
 }
 
-// buildDataSourceAttrPairChecks creates TestCheckResourceAttrPair checks for all tfvars fields.
-// This verifies the data source returns the same values as the created resource.
+// buildDataSourceAttrPairChecks returns attr-pair checks asserting the data source results match the resource.
 func buildDataSourceAttrPairChecks(dsAddr, resourceAddr string, tv *Tfvars) []resource.TestCheckFunc {
 	var checks []resource.TestCheckFunc
 
-	// Check common fields
 	for k := range tv.Common {
 		checks = append(checks, resource.TestCheckResourceAttrPair(
 			dsAddr, "results.0."+k,
@@ -182,7 +176,6 @@ func buildDataSourceAttrPairChecks(dsAddr, resourceAddr string, tv *Tfvars) []re
 		))
 	}
 
-	// Check backend-specific fields
 	if tv.Backend == "nios" {
 		for k := range tv.NIOS {
 			checks = append(checks, resource.TestCheckResourceAttrPair(


### PR DESCRIPTION
- Added configurable execution parameters to the test case runner to control which test cases are run (skip, filter, limit).
- Extended cases.go, cases_list.go, and cases_datasource.go with the new execution logic.
- Added inline documentation across these files to clarify the test execution flow.
- Cleaned up and standardized comments across all acctest files for consistency.