### PR TITLE
[NPA-3086][DNS] Add domain name validation for `absolute_name_spec` fields in UDDI Records

### DIFF
--- a/internal/service/dns/model_record_a.go
+++ b/internal/service/dns/model_record_a.go
@@ -242,6 +242,7 @@ var RecordAResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_aaaa.go
+++ b/internal/service/dns/model_record_aaaa.go
@@ -243,6 +243,7 @@ var RecordAaaaResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_caa.go
+++ b/internal/service/dns/model_record_caa.go
@@ -240,6 +240,7 @@ var RecordCaaResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_cname.go
+++ b/internal/service/dns/model_record_cname.go
@@ -228,6 +228,7 @@ var RecordCnameResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_dname.go
+++ b/internal/service/dns/model_record_dname.go
@@ -227,6 +227,7 @@ var RecordDnameResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_naptr.go
+++ b/internal/service/dns/model_record_naptr.go
@@ -278,6 +278,7 @@ var RecordNaptrResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_ns.go
+++ b/internal/service/dns/model_record_ns.go
@@ -167,6 +167,7 @@ var RecordNsResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},

--- a/internal/service/dns/model_record_txt.go
+++ b/internal/service/dns/model_record_txt.go
@@ -228,6 +228,7 @@ var RecordTxtResourceUddiSchemaAttributes = map[string]schema.Attribute{
 				path.MatchRelative().AtParent().AtName("zone"),
 				path.MatchRelative().AtParent().AtName("name_in_zone"),
 			),
+			customvalidator.IsValidUDDIDomainName(),
 		},
 		MarkdownDescription: "Synthetic field, used to determine _zone_ and/or _name_in_zone_ field for records.",
 	},


### PR DESCRIPTION
Add a domain name validator for absolute_name_spec to ensure the value is provided as a canonical FQDN with a trailing dot.