### PR TITLE
[NPA-3055][NPA-3094][ALL] Expose limit and paging params for UDDI data source

### DIFF
--- a/docs/data-sources/address.md
+++ b/docs/data-sources/address.md
@@ -15,10 +15,9 @@ Retrieves information about existing Infoblox Address from the UDDI backend.
 
 ### Optional
 
-- `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -3,12 +3,12 @@
 page_title: "infoblox_network Data Source - terraform-provider-infoblox"
 subcategory: "IPAM"
 description: |-
-  Retrieves information about existing Infoblox Network across NIOS and UDDI backends.
+  Retrieves information about existing Infoblox Network from both the NIOS and UDDI backends.
 ---
 
 # infoblox_network (Data Source)
 
-Retrieves information about existing Infoblox Network across NIOS and UDDI backends.
+Retrieves information about existing Infoblox Network from both the NIOS and UDDI backends.
 
 ## Example Usage
 
@@ -63,8 +63,9 @@ data "infoblox_network" "example_all" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/networkcontainer.md
+++ b/docs/data-sources/networkcontainer.md
@@ -62,8 +62,9 @@ data "infoblox_networkcontainer" "example_all" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_a.md
+++ b/docs/data-sources/record_a.md
@@ -56,8 +56,9 @@ data "infoblox_record_a" "get_all_a_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_aaaa.md
+++ b/docs/data-sources/record_aaaa.md
@@ -62,8 +62,9 @@ data "infoblox_record_aaaa" "get_all_aaaa_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_caa.md
+++ b/docs/data-sources/record_caa.md
@@ -62,8 +62,9 @@ data "infoblox_record_caa" "get_all_caa_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_cname.md
+++ b/docs/data-sources/record_cname.md
@@ -62,8 +62,9 @@ data "infoblox_record_cname" "get_all_cname_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_dname.md
+++ b/docs/data-sources/record_dname.md
@@ -62,8 +62,9 @@ data "infoblox_record_dname" "get_all_dname_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_naptr.md
+++ b/docs/data-sources/record_naptr.md
@@ -62,8 +62,9 @@ data "infoblox_record_naptr" "get_all_naptr_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_ns.md
+++ b/docs/data-sources/record_ns.md
@@ -54,10 +54,10 @@ data "infoblox_record_ns" "get_all_ns_records" {}
 
 ### Optional
 
-- `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/record_txt.md
+++ b/docs/data-sources/record_txt.md
@@ -62,8 +62,9 @@ data "infoblox_record_txt" "get_all_txt_records" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/view.md
+++ b/docs/data-sources/view.md
@@ -69,8 +69,9 @@ data "infoblox_view" "get_all_views" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/data-sources/zone_auth.md
+++ b/docs/data-sources/zone_auth.md
@@ -63,8 +63,9 @@ data "infoblox_zone_auth" "get_all_zones" {}
 
 - `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.
 - `filters` (Map of String) Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.
-- `max_results` (Number) Maximum number of results to return.
-- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.
+- `limit` (Number) Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.
+- `max_results` (Number) Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.
+- `paging` (Number) Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.
 - `tag_filters` (Map of String) Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.
 
 ### Read-Only

--- a/docs/list-resources/address.md
+++ b/docs/list-resources/address.md
@@ -15,6 +15,5 @@ Retrieves a list of Infoblox Address from the UDDI backend.
 
 ### Optional
 
-- `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to filter results by NIOS extensible attributes. Only applicable for the NIOS backend.
 - `filters` (Map of String) Filters are used to return a more specific list of results. Filters can be used to match resources by specific attributes (e.g. name, view). If multiple filters are specified, only resources that match all of them are returned.
 - `tag_filters` (Map of String) Tag Filters are used to filter results by UDDI tags. Only applicable for the UDDI backend.

--- a/docs/list-resources/network.md
+++ b/docs/list-resources/network.md
@@ -3,12 +3,12 @@
 page_title: "infoblox_network List Resource - terraform-provider-infoblox"
 subcategory: "IPAM"
 description: |-
-  Retrieves a list of Infoblox Network from the configured backend (NIOS or UDDI).
+  Retrieves a list of Infoblox Network from both the NIOS and UDDI backends.
 ---
 
 # infoblox_network (List Resource)
 
-Retrieves a list of Infoblox Network from the configured backend (NIOS or UDDI).
+Retrieves a list of Infoblox Network from both the NIOS and UDDI backends.
 
 ## Example Usage
 

--- a/docs/list-resources/record_ns.md
+++ b/docs/list-resources/record_ns.md
@@ -80,6 +80,5 @@ list "infoblox_record_ns" "list_records_with_resource" {
 
 ### Optional
 
-- `ext_attr_filters` (Map of String) Extensible Attribute Filters are used to filter results by NIOS extensible attributes. Only applicable for the NIOS backend.
 - `filters` (Map of String) Filters are used to return a more specific list of results. Filters can be used to match resources by specific attributes (e.g. name, view). If multiple filters are specified, only resources that match all of them are returned.
 - `tag_filters` (Map of String) Tag Filters are used to filter results by UDDI tags. Only applicable for the UDDI backend.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -3,12 +3,12 @@
 page_title: "infoblox_network Resource - terraform-provider-infoblox"
 subcategory: "IPAM"
 description: |-
-  Manages an Infoblox Network across NIOS and UDDI backends.
+  Manages an Infoblox Network in both NIOS and UDDI backends.
 ---
 
 # infoblox_network (Resource)
 
-Manages an Infoblox Network across NIOS and UDDI backends.
+Manages an Infoblox Network in both NIOS and UDDI backends.
 
 ## Example Usage
 

--- a/internal/core/service/dns/record_a.go
+++ b/internal/core/service/dns/record_a.go
@@ -288,15 +288,11 @@ func (s *recordAService) listNIOS(ctx context.Context, opts *core.ListOptions) (
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_aaaa.go
+++ b/internal/core/service/dns/record_aaaa.go
@@ -288,15 +288,11 @@ func (s *recordAaaaService) listNIOS(ctx context.Context, opts *core.ListOptions
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_caa.go
+++ b/internal/core/service/dns/record_caa.go
@@ -285,15 +285,11 @@ func (s *recordCaaService) listNIOS(ctx context.Context, opts *core.ListOptions)
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_cname.go
+++ b/internal/core/service/dns/record_cname.go
@@ -285,15 +285,11 @@ func (s *recordCnameService) listNIOS(ctx context.Context, opts *core.ListOption
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_dname.go
+++ b/internal/core/service/dns/record_dname.go
@@ -285,15 +285,11 @@ func (s *recordDnameService) listNIOS(ctx context.Context, opts *core.ListOption
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_naptr.go
+++ b/internal/core/service/dns/record_naptr.go
@@ -285,15 +285,11 @@ func (s *recordNaptrService) listNIOS(ctx context.Context, opts *core.ListOption
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_ns.go
+++ b/internal/core/service/dns/record_ns.go
@@ -275,15 +275,11 @@ func (s *recordNsService) listNIOS(ctx context.Context, opts *core.ListOptions) 
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/record_txt.go
+++ b/internal/core/service/dns/record_txt.go
@@ -285,15 +285,11 @@ func (s *recordTxtService) listNIOS(ctx context.Context, opts *core.ListOptions)
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/view.go
+++ b/internal/core/service/dns/view.go
@@ -285,15 +285,11 @@ func (s *viewService) listNIOS(ctx context.Context, opts *core.ListOptions) ([]*
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/dns/zone_auth.go
+++ b/internal/core/service/dns/zone_auth.go
@@ -285,15 +285,11 @@ func (s *zoneAuthService) listNIOS(ctx context.Context, opts *core.ListOptions) 
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/ipam/network.go
+++ b/internal/core/service/ipam/network.go
@@ -288,15 +288,11 @@ func (s *networkService) listNIOS(ctx context.Context, opts *core.ListOptions) (
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/service/ipam/networkcontainer.go
+++ b/internal/core/service/ipam/networkcontainer.go
@@ -288,15 +288,11 @@ func (s *networkcontainerService) listNIOS(ctx context.Context, opts *core.ListO
 			req = req.PageId(opts.PageID)
 		}
 		req = req.Paging(opts.Paging)
-		if opts.Paging == 1 {
-			maxResults := opts.MaxResults
-			if maxResults <= 0 {
-				maxResults = core.DefaultListLimit
-			}
-			req = req.MaxResults(maxResults)
-		} else if opts.MaxResults > 0 {
-			req = req.MaxResults(opts.MaxResults)
+		maxResults := opts.MaxResults
+		if maxResults <= 0 {
+			maxResults = core.DefaultListLimit
 		}
+		req = req.MaxResults(maxResults)
 	}
 
 	resp, httpResp, err := req.Execute()

--- a/internal/core/utils.go
+++ b/internal/core/utils.go
@@ -150,20 +150,31 @@ func ReadAllPagesNIOS[T any](fetchPage func(pageID string) ([]T, string, error))
 	return allResults, nil
 }
 
-// ReadAllPagesUDDI fetches all pages using offset/limit pagination
-func ReadAllPagesUDDI[T any](fetchPage func(offset, limit int32) ([]T, error)) ([]T, error) {
+// ReadAllPagesUDDI fetches all pages using offset/limit pagination.
+// pagingOpts, in order: page size (default DefaultListLimit), paging (0 = first page only).
+func ReadAllPagesUDDI[T any](fetchPage func(offset, limit int32) ([]T, error), pagingOpts ...int32) ([]T, error) {
+
+	pageSize, paging := DefaultListLimit, int32(1)
+
+	if len(pagingOpts) > 0 && pagingOpts[0] > 0 {
+		pageSize = pagingOpts[0]
+	}
+	if len(pagingOpts) > 1 {
+		paging = pagingOpts[1]
+	}
+
 	var allResults []T
 	var offset int32 = 0
 	for {
-		results, err := fetchPage(offset, DefaultListLimit)
+		results, err := fetchPage(offset, pageSize)
 		if err != nil {
 			return nil, err
 		}
 		allResults = append(allResults, results...)
-		if int32(len(results)) < DefaultListLimit {
+		if paging == 0 || int32(len(results)) < pageSize {
 			break
 		}
-		offset += DefaultListLimit
+		offset += pageSize
 	}
 	return allResults, nil
 }

--- a/internal/service/dns/record_a_data_source.go
+++ b/internal/service/dns/record_a_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordADataSource{}
@@ -45,6 +47,7 @@ type RecordADataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordADataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordADataSource) ValidateConfig(ctx context.Context, req datasource.V
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordADataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordADataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordADataSource) Read(ctx context.Context, req datasource.ReadRequest
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordA, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_a_list.go
+++ b/internal/service/dns/record_a_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordAList{}
-	_ list.ListResourceWithConfigure = &RecordAList{}
+	_ list.ListResource                   = &RecordAList{}
+	_ list.ListResourceWithConfigure      = &RecordAList{}
+	_ list.ListResourceWithValidateConfig = &RecordAList{}
 )
 
 func NewRecordAList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordAList) ListResourceConfigSchema(_ context.Context, _ list.ListRes
 	}
 }
 
-func (d *RecordAList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordAList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordAListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordAList) ValidateConfig(ctx context.Context, req datasource.Validat
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordAList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordAList) List(ctx context.Context, req list.ListRequest, stream *li
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_aaaa_data_source.go
+++ b/internal/service/dns/record_aaaa_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordAaaaDataSource{}
@@ -45,6 +47,7 @@ type RecordAaaaDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordAaaaDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordAaaaDataSource) ValidateConfig(ctx context.Context, req datasourc
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordAaaaDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordAaaaDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordAaaaDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordAaaa, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_aaaa_list.go
+++ b/internal/service/dns/record_aaaa_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordAaaaList{}
-	_ list.ListResourceWithConfigure = &RecordAaaaList{}
+	_ list.ListResource                   = &RecordAaaaList{}
+	_ list.ListResourceWithConfigure      = &RecordAaaaList{}
+	_ list.ListResourceWithValidateConfig = &RecordAaaaList{}
 )
 
 func NewRecordAaaaList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordAaaaList) ListResourceConfigSchema(_ context.Context, _ list.List
 	}
 }
 
-func (d *RecordAaaaList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordAaaaList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordAaaaListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordAaaaList) ValidateConfig(ctx context.Context, req datasource.Vali
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordAaaaList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordAaaaList) List(ctx context.Context, req list.ListRequest, stream 
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_caa_data_source.go
+++ b/internal/service/dns/record_caa_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordCaaDataSource{}
@@ -45,6 +47,7 @@ type RecordCaaDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordCaaDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordCaaDataSource) ValidateConfig(ctx context.Context, req datasource
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordCaaDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordCaaDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordCaaDataSource) Read(ctx context.Context, req datasource.ReadReque
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordCaa, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_caa_list.go
+++ b/internal/service/dns/record_caa_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordCaaList{}
-	_ list.ListResourceWithConfigure = &RecordCaaList{}
+	_ list.ListResource                   = &RecordCaaList{}
+	_ list.ListResourceWithConfigure      = &RecordCaaList{}
+	_ list.ListResourceWithValidateConfig = &RecordCaaList{}
 )
 
 func NewRecordCaaList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordCaaList) ListResourceConfigSchema(_ context.Context, _ list.ListR
 	}
 }
 
-func (d *RecordCaaList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordCaaList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordCaaListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordCaaList) ValidateConfig(ctx context.Context, req datasource.Valid
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordCaaList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordCaaList) List(ctx context.Context, req list.ListRequest, stream *
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_cname_data_source.go
+++ b/internal/service/dns/record_cname_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordCnameDataSource{}
@@ -45,6 +47,7 @@ type RecordCnameDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordCnameDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordCnameDataSource) ValidateConfig(ctx context.Context, req datasour
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordCnameDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordCnameDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordCnameDataSource) Read(ctx context.Context, req datasource.ReadReq
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordCname, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_cname_list.go
+++ b/internal/service/dns/record_cname_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordCnameList{}
-	_ list.ListResourceWithConfigure = &RecordCnameList{}
+	_ list.ListResource                   = &RecordCnameList{}
+	_ list.ListResourceWithConfigure      = &RecordCnameList{}
+	_ list.ListResourceWithValidateConfig = &RecordCnameList{}
 )
 
 func NewRecordCnameList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordCnameList) ListResourceConfigSchema(_ context.Context, _ list.Lis
 	}
 }
 
-func (d *RecordCnameList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordCnameList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordCnameListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordCnameList) ValidateConfig(ctx context.Context, req datasource.Val
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordCnameList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordCnameList) List(ctx context.Context, req list.ListRequest, stream
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_dname_data_source.go
+++ b/internal/service/dns/record_dname_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordDnameDataSource{}
@@ -45,6 +47,7 @@ type RecordDnameDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordDnameDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordDnameDataSource) ValidateConfig(ctx context.Context, req datasour
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordDnameDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordDnameDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordDnameDataSource) Read(ctx context.Context, req datasource.ReadReq
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordDname, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_dname_list.go
+++ b/internal/service/dns/record_dname_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordDnameList{}
-	_ list.ListResourceWithConfigure = &RecordDnameList{}
+	_ list.ListResource                   = &RecordDnameList{}
+	_ list.ListResourceWithConfigure      = &RecordDnameList{}
+	_ list.ListResourceWithValidateConfig = &RecordDnameList{}
 )
 
 func NewRecordDnameList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordDnameList) ListResourceConfigSchema(_ context.Context, _ list.Lis
 	}
 }
 
-func (d *RecordDnameList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordDnameList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordDnameListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordDnameList) ValidateConfig(ctx context.Context, req datasource.Val
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordDnameList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordDnameList) List(ctx context.Context, req list.ListRequest, stream
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_naptr_data_source.go
+++ b/internal/service/dns/record_naptr_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordNaptrDataSource{}
@@ -45,6 +47,7 @@ type RecordNaptrDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordNaptrDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordNaptrDataSource) ValidateConfig(ctx context.Context, req datasour
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordNaptrDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordNaptrDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordNaptrDataSource) Read(ctx context.Context, req datasource.ReadReq
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordNaptr, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_naptr_list.go
+++ b/internal/service/dns/record_naptr_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordNaptrList{}
-	_ list.ListResourceWithConfigure = &RecordNaptrList{}
+	_ list.ListResource                   = &RecordNaptrList{}
+	_ list.ListResourceWithConfigure      = &RecordNaptrList{}
+	_ list.ListResourceWithValidateConfig = &RecordNaptrList{}
 )
 
 func NewRecordNaptrList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordNaptrList) ListResourceConfigSchema(_ context.Context, _ list.Lis
 	}
 }
 
-func (d *RecordNaptrList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordNaptrList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordNaptrListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordNaptrList) ValidateConfig(ctx context.Context, req datasource.Val
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordNaptrList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordNaptrList) List(ctx context.Context, req list.ListRequest, stream
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/record_ns_data_source.go
+++ b/internal/service/dns/record_ns_data_source.go
@@ -41,13 +41,12 @@ func (d *RecordNsDataSource) Metadata(_ context.Context, req datasource.Metadata
 
 // RecordNsDataSourceModel is the filter model for the datasource
 type RecordNsDataSourceModel struct {
-	Filters        types.Map   `tfsdk:"filters"`
-	ExtAttrFilters types.Map   `tfsdk:"ext_attr_filters"`
-	TagFilters     types.Map   `tfsdk:"tag_filters"`
-	Results        types.List  `tfsdk:"results"`
-	MaxResults     types.Int32 `tfsdk:"max_results"`
-	Paging         types.Int32 `tfsdk:"paging"`
-	Limit          types.Int32 `tfsdk:"limit"`
+	Filters    types.Map   `tfsdk:"filters"`
+	TagFilters types.Map   `tfsdk:"tag_filters"`
+	Results    types.List  `tfsdk:"results"`
+	MaxResults types.Int32 `tfsdk:"max_results"`
+	Paging     types.Int32 `tfsdk:"paging"`
+	Limit      types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -75,11 +74,6 @@ func (d *RecordNsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 		Attributes: map[string]schema.Attribute{
 			"filters": schema.MapAttribute{
 				Description: "Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.",
-				ElementType: types.StringType,
-				Optional:    true,
-			},
-			"ext_attr_filters": schema.MapAttribute{
-				Description: "Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.",
 				ElementType: types.StringType,
 				Optional:    true,
 			},
@@ -144,7 +138,7 @@ func (d *RecordNsDataSource) ValidateConfig(ctx context.Context, req datasource.
 		return
 	}
 
-	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, types.MapNull(types.StringType), data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordNsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -159,7 +153,6 @@ func (d *RecordNsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	opts := &core.ListOptions{
 		Filters:         flex.ExpandMapString(ctx, data.Filters, &resp.Diagnostics),
 		InternalFilters: map[string]string{"type": RecordNsType},
-		ExtAttrFilter:   flex.ExpandMapString(ctx, data.ExtAttrFilters, &resp.Diagnostics),
 		TagFilter:       flex.ExpandMapString(ctx, data.TagFilters, &resp.Diagnostics),
 		ReturnFields:    RecordNsReturnFields,
 		Paging:          1,

--- a/internal/service/dns/record_ns_data_source.go
+++ b/internal/service/dns/record_ns_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordNsDataSource{}
@@ -45,6 +47,7 @@ type RecordNsDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordNsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordNsDataSource) ValidateConfig(ctx context.Context, req datasource.
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordNsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordNsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordNsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordNs, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_ns_list.go
+++ b/internal/service/dns/record_ns_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordNsList{}
-	_ list.ListResourceWithConfigure = &RecordNsList{}
+	_ list.ListResource                   = &RecordNsList{}
+	_ list.ListResourceWithConfigure      = &RecordNsList{}
+	_ list.ListResourceWithValidateConfig = &RecordNsList{}
 )
 
 func NewRecordNsList() list.ListResource {
@@ -35,9 +35,8 @@ type RecordNsList struct {
 }
 
 type RecordNsListModel struct {
-	Filters        types.Map `tfsdk:"filters"`
-	ExtAttrFilters types.Map `tfsdk:"ext_attr_filters"`
-	TagFilters     types.Map `tfsdk:"tag_filters"`
+	Filters    types.Map `tfsdk:"filters"`
+	TagFilters types.Map `tfsdk:"tag_filters"`
 }
 
 func (l *RecordNsList) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -76,11 +75,6 @@ func (l *RecordNsList) ListResourceConfigSchema(_ context.Context, _ list.ListRe
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
-			"ext_attr_filters": listschema.MapAttribute{
-				MarkdownDescription: "Extensible Attribute Filters are used to filter results by NIOS extensible attributes. Only applicable for the NIOS backend.",
-				ElementType:         types.StringType,
-				Optional:            true,
-			},
 			"tag_filters": listschema.MapAttribute{
 				MarkdownDescription: "Tag Filters are used to filter results by UDDI tags. Only applicable for the UDDI backend.",
 				ElementType:         types.StringType,
@@ -90,7 +84,7 @@ func (l *RecordNsList) ListResourceConfigSchema(_ context.Context, _ list.ListRe
 	}
 }
 
-func (d *RecordNsList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordNsList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordNsListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +92,7 @@ func (d *RecordNsList) ValidateConfig(ctx context.Context, req datasource.Valida
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, types.MapNull(types.StringType), data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordNsList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -110,26 +104,6 @@ func (l *RecordNsList) List(ctx context.Context, req list.ListRequest, stream *l
 		return
 	}
 
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
 	requestLimit := int32(req.Limit)
 	tflog.Info(ctx, fmt.Sprintf("infoblox_record_ns list: req.Limit=%d backend=%s includeResource=%t",
 		req.Limit, l.backend, req.IncludeResource))
@@ -137,7 +111,6 @@ func (l *RecordNsList) List(ctx context.Context, req list.ListRequest, stream *l
 	opts := &core.ListOptions{
 		Filters:         flex.ExpandMapString(ctx, data.Filters, &diags),
 		InternalFilters: map[string]string{"type": RecordNsType},
-		ExtAttrFilter:   flex.ExpandMapString(ctx, data.ExtAttrFilters, &diags),
 		TagFilter:       flex.ExpandMapString(ctx, data.TagFilters, &diags),
 		ReturnFields:    RecordNsReturnFields,
 		Paging:          1,

--- a/internal/service/dns/record_txt_data_source.go
+++ b/internal/service/dns/record_txt_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &RecordTxtDataSource{}
@@ -45,6 +47,7 @@ type RecordTxtDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *RecordTxtDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *RecordTxtDataSource) ValidateConfig(ctx context.Context, req datasource
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *RecordTxtDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -161,6 +171,9 @@ func (d *RecordTxtDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,9 +192,10 @@ func (d *RecordTxtDataSource) Read(ctx context.Context, req datasource.ReadReque
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.RecordTxt, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/record_txt_list.go
+++ b/internal/service/dns/record_txt_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &RecordTxtList{}
-	_ list.ListResourceWithConfigure = &RecordTxtList{}
+	_ list.ListResource                   = &RecordTxtList{}
+	_ list.ListResourceWithConfigure      = &RecordTxtList{}
+	_ list.ListResourceWithValidateConfig = &RecordTxtList{}
 )
 
 func NewRecordTxtList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *RecordTxtList) ListResourceConfigSchema(_ context.Context, _ list.ListR
 	}
 }
 
-func (d *RecordTxtList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *RecordTxtList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data RecordTxtListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *RecordTxtList) ValidateConfig(ctx context.Context, req datasource.Valid
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *RecordTxtList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *RecordTxtList) List(ctx context.Context, req list.ListRequest, stream *
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/view_data_source.go
+++ b/internal/service/dns/view_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &ViewDataSource{}
@@ -45,6 +47,7 @@ type ViewDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *ViewDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *ViewDataSource) ValidateConfig(ctx context.Context, req datasource.Vali
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *ViewDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -160,6 +170,9 @@ func (d *ViewDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,9 +191,10 @@ func (d *ViewDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.View, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/view_list.go
+++ b/internal/service/dns/view_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &ViewList{}
-	_ list.ListResourceWithConfigure = &ViewList{}
+	_ list.ListResource                   = &ViewList{}
+	_ list.ListResourceWithConfigure      = &ViewList{}
+	_ list.ListResourceWithValidateConfig = &ViewList{}
 )
 
 func NewViewList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *ViewList) ListResourceConfigSchema(_ context.Context, _ list.ListResour
 	}
 }
 
-func (d *ViewList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *ViewList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data ViewListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *ViewList) ValidateConfig(ctx context.Context, req datasource.ValidateCo
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *ViewList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *ViewList) List(ctx context.Context, req list.ListRequest, stream *list.
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/dns/zone_auth_data_source.go
+++ b/internal/service/dns/zone_auth_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &ZoneAuthDataSource{}
@@ -45,6 +47,7 @@ type ZoneAuthDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *ZoneAuthDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *ZoneAuthDataSource) ValidateConfig(ctx context.Context, req datasource.
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *ZoneAuthDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -160,6 +170,9 @@ func (d *ZoneAuthDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,9 +191,10 @@ func (d *ZoneAuthDataSource) Read(ctx context.Context, req datasource.ReadReques
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.ZoneAuth, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/dns/zone_auth_list.go
+++ b/internal/service/dns/zone_auth_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &ZoneAuthList{}
-	_ list.ListResourceWithConfigure = &ZoneAuthList{}
+	_ list.ListResource                   = &ZoneAuthList{}
+	_ list.ListResourceWithConfigure      = &ZoneAuthList{}
+	_ list.ListResourceWithValidateConfig = &ZoneAuthList{}
 )
 
 func NewZoneAuthList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *ZoneAuthList) ListResourceConfigSchema(_ context.Context, _ list.ListRe
 	}
 }
 
-func (d *ZoneAuthList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *ZoneAuthList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data ZoneAuthListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *ZoneAuthList) ValidateConfig(ctx context.Context, req datasource.Valida
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *ZoneAuthList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *ZoneAuthList) List(ctx context.Context, req list.ListRequest, stream *l
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/ipam/address_data_source.go
+++ b/internal/service/ipam/address_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &AddressDataSource{}
@@ -39,12 +41,11 @@ func (d *AddressDataSource) Metadata(_ context.Context, req datasource.MetadataR
 
 // AddressDataSourceModel is the filter model for the datasource
 type AddressDataSourceModel struct {
-	Filters        types.Map   `tfsdk:"filters"`
-	ExtAttrFilters types.Map   `tfsdk:"ext_attr_filters"`
-	TagFilters     types.Map   `tfsdk:"tag_filters"`
-	Results        types.List  `tfsdk:"results"`
-	MaxResults     types.Int32 `tfsdk:"max_results"`
-	Paging         types.Int32 `tfsdk:"paging"`
+	Filters    types.Map   `tfsdk:"filters"`
+	TagFilters types.Map   `tfsdk:"tag_filters"`
+	Results    types.List  `tfsdk:"results"`
+	Paging     types.Int32 `tfsdk:"paging"`
+	Limit      types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -75,11 +76,6 @@ func (d *AddressDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				ElementType: types.StringType,
 				Optional:    true,
 			},
-			"ext_attr_filters": schema.MapAttribute{
-				Description: "Extensible Attribute Filters are used to return a more specific list of results by filtering on extensible attributes. Only applicable for NIOS backend.",
-				ElementType: types.StringType,
-				Optional:    true,
-			},
 			"tag_filters": schema.MapAttribute{
 				Description: "Tag Filters are used to return a more specific list of results filtered by tags. Only applicable for UDDI backend.",
 				ElementType: types.StringType,
@@ -93,11 +89,14 @@ func (d *AddressDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
-			"max_results": schema.Int32Attribute{
+			"limit": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +133,7 @@ func (d *AddressDataSource) ValidateConfig(ctx context.Context, req datasource.V
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, types.Int32Null(), &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, types.MapNull(types.StringType), data.TagFilters, types.Int32Null(), data.Limit, &resp.Diagnostics)
 }
 
 func (d *AddressDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -147,18 +146,17 @@ func (d *AddressDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	// Build list options
 	opts := &core.ListOptions{
-		Filters:       flex.ExpandMapString(ctx, data.Filters, &resp.Diagnostics),
-		ExtAttrFilter: flex.ExpandMapString(ctx, data.ExtAttrFilters, &resp.Diagnostics),
-		TagFilter:     flex.ExpandMapString(ctx, data.TagFilters, &resp.Diagnostics),
-		ReturnFields:  AddressReturnFields,
-		Paging:        1,
+		Filters:      flex.ExpandMapString(ctx, data.Filters, &resp.Diagnostics),
+		TagFilter:    flex.ExpandMapString(ctx, data.TagFilters, &resp.Diagnostics),
+		ReturnFields: AddressReturnFields,
+		Paging:       1,
 	}
 
-	if !data.MaxResults.IsNull() {
-		opts.MaxResults = data.MaxResults.ValueInt32()
-	}
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
+	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
 	}
 
 	if resp.Diagnostics.HasError() {
@@ -178,9 +176,10 @@ func (d *AddressDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.Address, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/ipam/address_data_source.go
+++ b/internal/service/ipam/address_data_source.go
@@ -134,7 +134,7 @@ func (d *AddressDataSource) ValidateConfig(ctx context.Context, req datasource.V
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, types.Int32Null(), &resp.Diagnostics)
 }
 
 func (d *AddressDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/service/ipam/address_list.go
+++ b/internal/service/ipam/address_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &AddressList{}
-	_ list.ListResourceWithConfigure = &AddressList{}
+	_ list.ListResource                   = &AddressList{}
+	_ list.ListResourceWithConfigure      = &AddressList{}
+	_ list.ListResourceWithValidateConfig = &AddressList{}
 )
 
 func NewAddressList() list.ListResource {
@@ -35,9 +35,8 @@ type AddressList struct {
 }
 
 type AddressListModel struct {
-	Filters        types.Map `tfsdk:"filters"`
-	ExtAttrFilters types.Map `tfsdk:"ext_attr_filters"`
-	TagFilters     types.Map `tfsdk:"tag_filters"`
+	Filters    types.Map `tfsdk:"filters"`
+	TagFilters types.Map `tfsdk:"tag_filters"`
 }
 
 func (l *AddressList) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -76,11 +75,6 @@ func (l *AddressList) ListResourceConfigSchema(_ context.Context, _ list.ListRes
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
-			"ext_attr_filters": listschema.MapAttribute{
-				MarkdownDescription: "Extensible Attribute Filters are used to filter results by NIOS extensible attributes. Only applicable for the NIOS backend.",
-				ElementType:         types.StringType,
-				Optional:            true,
-			},
 			"tag_filters": listschema.MapAttribute{
 				MarkdownDescription: "Tag Filters are used to filter results by UDDI tags. Only applicable for the UDDI backend.",
 				ElementType:         types.StringType,
@@ -90,7 +84,7 @@ func (l *AddressList) ListResourceConfigSchema(_ context.Context, _ list.ListRes
 	}
 }
 
-func (d *AddressList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *AddressList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data AddressListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +92,7 @@ func (d *AddressList) ValidateConfig(ctx context.Context, req datasource.Validat
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, types.MapNull(types.StringType), data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *AddressList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -110,36 +104,15 @@ func (l *AddressList) List(ctx context.Context, req list.ListRequest, stream *li
 		return
 	}
 
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
 	requestLimit := int32(req.Limit)
 	tflog.Info(ctx, fmt.Sprintf("infoblox_address list: req.Limit=%d backend=%s includeResource=%t",
 		req.Limit, l.backend, req.IncludeResource))
 
 	opts := &core.ListOptions{
-		Filters:       flex.ExpandMapString(ctx, data.Filters, &diags),
-		ExtAttrFilter: flex.ExpandMapString(ctx, data.ExtAttrFilters, &diags),
-		TagFilter:     flex.ExpandMapString(ctx, data.TagFilters, &diags),
-		ReturnFields:  AddressReturnFields,
-		Paging:        1,
+		Filters:      flex.ExpandMapString(ctx, data.Filters, &diags),
+		TagFilter:    flex.ExpandMapString(ctx, data.TagFilters, &diags),
+		ReturnFields: AddressReturnFields,
+		Paging:       1,
 	}
 	if diags.HasError() {
 		stream.Results = list.ListResultsStreamDiagnostics(diags)

--- a/internal/service/ipam/address_resource.go
+++ b/internal/service/ipam/address_resource.go
@@ -5,15 +5,18 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/core"
 	coremodel "github.com/infobloxopen/terraform-provider-infoblox/internal/core/model/ipam"
 	coresvc "github.com/infobloxopen/terraform-provider-infoblox/internal/core/service/ipam"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/retry"
+	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var (
@@ -88,6 +91,12 @@ func (r *AddressResource) ValidateConfig(ctx context.Context, req resource.Valid
 	var data AddressModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Common backend block validations
+	validator.ValidateBackendBlocks(r.backend, types.ObjectNull(map[string]attr.Type{}), data.UDDI, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/ipam/model_asm_config.go
+++ b/internal/service/ipam/model_asm_config.go
@@ -105,7 +105,6 @@ var ASMConfigResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional:            true,
 		Computed:            true,
 		CustomType:          timetypes.RFC3339Type{},
-		Default:             stringdefault.StaticString("1970-01-01T00:00:00Z"),
 		MarkdownDescription: "",
 	},
 }

--- a/internal/service/ipam/network_data_source.go
+++ b/internal/service/ipam/network_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &NetworkDataSource{}
@@ -45,6 +47,7 @@ type NetworkDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -68,7 +71,7 @@ func (m *NetworkDataSourceModel) FlattenResults(ctx context.Context, from []*cor
 
 func (d *NetworkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Retrieves information about existing Infoblox Network across NIOS and UDDI backends.",
+		MarkdownDescription: "Retrieves information about existing Infoblox Network from both the NIOS and UDDI backends.",
 		Attributes: map[string]schema.Attribute{
 			"filters": schema.MapAttribute{
 				Description: "Filter are used to return a more specific list of results. Filters can be used to match resources by specific attributes.",
@@ -93,11 +96,18 @@ func (d *NetworkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *NetworkDataSource) ValidateConfig(ctx context.Context, req datasource.V
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *NetworkDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -160,6 +170,9 @@ func (d *NetworkDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,9 +191,10 @@ func (d *NetworkDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.Network, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/ipam/network_list.go
+++ b/internal/service/ipam/network_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &NetworkList{}
-	_ list.ListResourceWithConfigure = &NetworkList{}
+	_ list.ListResource                   = &NetworkList{}
+	_ list.ListResourceWithConfigure      = &NetworkList{}
+	_ list.ListResourceWithValidateConfig = &NetworkList{}
 )
 
 func NewNetworkList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *NetworkList) ListResourceConfigSchema(_ context.Context, _ list.ListRes
 	}
 }
 
-func (d *NetworkList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *NetworkList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data NetworkListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *NetworkList) ValidateConfig(ctx context.Context, req datasource.Validat
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *NetworkList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *NetworkList) List(ctx context.Context, req list.ListRequest, stream *li
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/service/ipam/network_list.go
+++ b/internal/service/ipam/network_list.go
@@ -69,7 +69,7 @@ func (l *NetworkList) Configure(_ context.Context, req resource.ConfigureRequest
 
 func (l *NetworkList) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
 	resp.Schema = listschema.Schema{
-		MarkdownDescription: "Retrieves a list of Infoblox Network from the configured backend (NIOS or UDDI).",
+		MarkdownDescription: "Retrieves a list of Infoblox Network from both the NIOS and UDDI backends.",
 		Attributes: map[string]listschema.Attribute{
 			"filters": listschema.MapAttribute{
 				MarkdownDescription: "Filters are used to return a more specific list of results. Filters can be used to match resources by specific attributes (e.g. name, view). If multiple filters are specified, only resources that match all of them are returned.",

--- a/internal/service/ipam/network_resource.go
+++ b/internal/service/ipam/network_resource.go
@@ -57,7 +57,7 @@ func (r *NetworkResource) IdentitySchema(_ context.Context, _ resource.IdentityS
 
 func (r *NetworkResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages an Infoblox Network across NIOS and UDDI backends.",
+		MarkdownDescription: "Manages an Infoblox Network in both NIOS and UDDI backends.",
 		Attributes:          NetworkResourceSchemaAttributes,
 	}
 }

--- a/internal/service/ipam/networkcontainer_data_source.go
+++ b/internal/service/ipam/networkcontainer_data_source.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -17,7 +19,7 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/utils"
-	"github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
+	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
 var _ datasource.DataSource = &NetworkcontainerDataSource{}
@@ -45,6 +47,7 @@ type NetworkcontainerDataSourceModel struct {
 	Results        types.List  `tfsdk:"results"`
 	MaxResults     types.Int32 `tfsdk:"max_results"`
 	Paging         types.Int32 `tfsdk:"paging"`
+	Limit          types.Int32 `tfsdk:"limit"`
 }
 
 // FlattenResults flattens core records to the Results list using existing Flatten method.
@@ -93,11 +96,18 @@ func (d *NetworkcontainerDataSource) Schema(_ context.Context, _ datasource.Sche
 			},
 			"paging": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Enable (1) or disable (0) paging for the data source query. Only applicable for NIOS backend.",
+				Description: "Enable (1) or disable (0) paging for the data source query. Enabled by default. When disabled, only a single page of results is retrieved.",
+				Validators: []validator.Int32{
+					int32validator.OneOf(0, 1),
+				},
 			},
 			"max_results": schema.Int32Attribute{
 				Optional:    true,
-				Description: "Maximum number of results to return.",
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for NIOS backend.",
+			},
+			"limit": schema.Int32Attribute{
+				Optional:    true,
+				Description: "Number of results to return per page. Defaults to 1000. Only applicable for UDDI backend.",
 			},
 		},
 	}
@@ -134,7 +144,7 @@ func (d *NetworkcontainerDataSource) ValidateConfig(ctx context.Context, req dat
 		return
 	}
 
-	validator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Paging, &resp.Diagnostics)
+	customvalidator.ValidateDataSourceFilters(d.backend, data.ExtAttrFilters, data.TagFilters, data.MaxResults, data.Limit, &resp.Diagnostics)
 }
 
 func (d *NetworkcontainerDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -160,6 +170,9 @@ func (d *NetworkcontainerDataSource) Read(ctx context.Context, req datasource.Re
 	if !data.Paging.IsNull() {
 		opts.Paging = data.Paging.ValueInt32()
 	}
+	if !data.Limit.IsNull() {
+		opts.Limit = data.Limit.ValueInt32()
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,9 +191,10 @@ func (d *NetworkcontainerDataSource) Read(ctx context.Context, req datasource.Re
 	case core.BackendUDDI:
 		allResults, err = core.ReadAllPagesUDDI(func(offset, limit int32) ([]*coremodel.Networkcontainer, error) {
 			opts.Offset = offset
+			opts.Limit = limit
 			recs, _, _, e := d.service.List(ctx, opts)
 			return recs, e
-		})
+		}, opts.Limit, opts.Paging)
 	}
 
 	if err != nil {

--- a/internal/service/ipam/networkcontainer_list.go
+++ b/internal/service/ipam/networkcontainer_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -21,8 +20,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ list.ListResource              = &NetworkcontainerList{}
-	_ list.ListResourceWithConfigure = &NetworkcontainerList{}
+	_ list.ListResource                   = &NetworkcontainerList{}
+	_ list.ListResourceWithConfigure      = &NetworkcontainerList{}
+	_ list.ListResourceWithValidateConfig = &NetworkcontainerList{}
 )
 
 func NewNetworkcontainerList() list.ListResource {
@@ -90,7 +90,7 @@ func (l *NetworkcontainerList) ListResourceConfigSchema(_ context.Context, _ lis
 	}
 }
 
-func (d *NetworkcontainerList) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+func (l *NetworkcontainerList) ValidateListResourceConfig(ctx context.Context, req list.ValidateConfigRequest, resp *list.ValidateConfigResponse) {
 	var data NetworkcontainerListModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -98,7 +98,7 @@ func (d *NetworkcontainerList) ValidateConfig(ctx context.Context, req datasourc
 		return
 	}
 
-	validator.ValidateListFilters(d.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
+	validator.ValidateListFilters(l.backend, data.ExtAttrFilters, data.TagFilters, &resp.Diagnostics)
 }
 
 func (l *NetworkcontainerList) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -106,26 +106,6 @@ func (l *NetworkcontainerList) List(ctx context.Context, req list.ListRequest, s
 
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
-	// Backend-specific filter validation.
-	if l.backend == core.BackendNIOS && !data.TagFilters.IsNull() && !data.TagFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("tag_filters"),
-			"Invalid filter for NIOS backend",
-			"tag_filters is only supported on the UDDI backend. Use ext_attr_filters for NIOS.",
-		)
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-	if l.backend == core.BackendUDDI && !data.ExtAttrFilters.IsNull() && !data.ExtAttrFilters.IsUnknown() {
-		diags.AddAttributeError(
-			path.Root("ext_attr_filters"),
-			"Invalid filter for UDDI backend",
-			"ext_attr_filters is only supported on the NIOS backend. Use tag_filters for UDDI.",
-		)
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}

--- a/internal/validator/common.go
+++ b/internal/validator/common.go
@@ -50,7 +50,7 @@ func AddBackendFieldError(diags *diag.Diagnostics, fieldName, requiredBackend st
 }
 
 // ValidateDataSourceFilters validates backend-specific filter fields for datasources.
-func ValidateDataSourceFilters(backend core.BackendType, extAttrFilters, tagFilters types.Map, maxResults, paging types.Int32, diags *diag.Diagnostics) {
+func ValidateDataSourceFilters(backend core.BackendType, extAttrFilters, tagFilters types.Map, maxResults, limit types.Int32, diags *diag.Diagnostics) {
 	// ext_attr_filters is NIOS only
 	if !extAttrFilters.IsNull() && backend == core.BackendUDDI {
 		AddBackendFieldError(diags, "ext_attr_filters", "NIOS")
@@ -61,9 +61,9 @@ func ValidateDataSourceFilters(backend core.BackendType, extAttrFilters, tagFilt
 		AddBackendFieldError(diags, "max_results", "NIOS")
 	}
 
-	// paging is NIOS only
-	if !paging.IsNull() && backend == core.BackendUDDI {
-		AddBackendFieldError(diags, "paging", "NIOS")
+	// limit is UDDI only
+	if !limit.IsNull() && backend == core.BackendNIOS {
+		AddBackendFieldError(diags, "limit", "UDDI")
 	}
 
 	// tag_filters is UDDI only

--- a/internal/validator/common.go
+++ b/internal/validator/common.go
@@ -75,12 +75,12 @@ func ValidateDataSourceFilters(backend core.BackendType, extAttrFilters, tagFilt
 // ValidateListFilters validates backend-specific filter fields for lists.
 func ValidateListFilters(backend core.BackendType, extAttrFilters, tagFilters types.Map, diags *diag.Diagnostics) {
 	// ext_attr_filters is NIOS only
-	if !extAttrFilters.IsNull() && backend == core.BackendUDDI {
+	if !extAttrFilters.IsNull() && !extAttrFilters.IsUnknown() && backend == core.BackendUDDI {
 		AddBackendFieldError(diags, "ext_attr_filters", "NIOS")
 	}
 
 	// tag_filters is UDDI only
-	if !tagFilters.IsNull() && backend == core.BackendNIOS {
+	if !tagFilters.IsNull() && !tagFilters.IsUnknown() && backend == core.BackendNIOS {
 		AddBackendFieldError(diags, "tag_filters", "UDDI")
 	}
 }


### PR DESCRIPTION
- Adds a `limit` parameter to UDDI data sources so users can control the pagesize, which was previously hardcoded to 1000. `paging` now applies to both backends, matching the existing NIOS `max_results` behaviour.
- Fixed list config validation to use `ValidateListResourceConfig`
- [NPA-3094] -Fix the common validation for nios only and uddi only objs