### PR TITLE
NPA-3145: Fixed NIOS Passthru error string when license is set but passthru flag is disabled

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -225,9 +225,10 @@ func (p *InfobloxProvider) Configure(ctx context.Context, req provider.Configure
 			if data.UDDI.NIOSLicenseUID.ValueString() != "" {
 				resp.Diagnostics.AddError(
 					"Invalid Configuration",
-					"'uddi.nios_license_uid' is set but 'uddi.enable_nios_passthru' is not true. "+
-						"Set 'enable_nios_passthru = true' and 'portal_url' to the Infoblox Portal's WAPI endpoint to manage NIOS through the Infoblox Portal, "+
-						"or remove the license UID and set 'portal_url' to the Infoblox Portal URL to manage UDDI objects.",
+					"'uddi.nios_license_uid' is set but 'uddi.enable_nios_passthru' is not true.\n\n"+
+						"For NIOS via the Infoblox Portal: set 'enable_nios_passthru = true' and 'portal_url' to the Portal's WAPI passthrough endpoint.\n"+
+						"For UDDI objects: remove 'uddi.nios_license_uid' and set 'portal_url' to the Portal's CSP endpoint.\n\n"+
+						"These are different URLs, so 'portal_url' must match the mode.",
 				)
 				return
 			}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -225,7 +225,9 @@ func (p *InfobloxProvider) Configure(ctx context.Context, req provider.Configure
 			if data.UDDI.NIOSLicenseUID.ValueString() != "" {
 				resp.Diagnostics.AddError(
 					"Invalid Configuration",
-					"'uddi.nios_license_uid' is set but 'uddi.enable_nios_passthru' is not true. Set 'enable_nios_passthru = true' to manage NIOS through the Infoblox Portal, or remove the license UID to manage UDDI objects.",
+					"'uddi.nios_license_uid' is set but 'uddi.enable_nios_passthru' is not true. "+
+						"Set 'enable_nios_passthru = true' and 'portal_url' to the Infoblox Portal's WAPI endpoint to manage NIOS through the Infoblox Portal, "+
+						"or remove the license UID and set 'portal_url' to the Infoblox Portal URL to manage UDDI objects.",
 				)
 				return
 			}


### PR DESCRIPTION
Fixed NIOS Passthru error string when license-uid is set but passthru flag is disabled.
New error string will be like below.

<img width="2640" height="560" alt="image" src="https://github.com/user-attachments/assets/5b752795-9c70-43a4-96a0-10fe2fc8a396" />
