### PR TITLE
[NPA-3169] Remove importmod Plan Modifier from objects that doesn't support Terraform Internal ID

### DIFF
--- a/docs/data-sources/sharedrecord_a.md
+++ b/docs/data-sources/sharedrecord_a.md
@@ -64,7 +64,7 @@ Read-Only:
 - `comment` (String) Comment for this shared record; maximum 256 characters.
 - `disable` (Boolean) Determines if this shared record is disabled or not. False means that the record is enabled.
 - `ext_attrs` (Map of String) Extensible attributes associated with the object. For valid values for extensible attributes, see {extattrs:values}.
-- `ext_attrs_all` (Map of String) All ext_attrs including Terraform Internal ID and inherited attributes.
+- `ext_attrs_all` (Map of String) All ext_attrs including inherited values.
 - `ipv4addr` (String) The IPv4 Address of the shared record.
 - `name` (String) Name for this shared record. This value can be in unicode format.
 - `shared_record_group` (String) The name of the shared record group in which the record resides.

--- a/docs/data-sources/sharedrecord_aaaa.md
+++ b/docs/data-sources/sharedrecord_aaaa.md
@@ -64,7 +64,7 @@ Read-Only:
 - `comment` (String) Comment for this shared record; maximum 256 characters.
 - `disable` (Boolean) Determines if this shared record is disabled or not. False means that the record is enabled.
 - `ext_attrs` (Map of String) Extensible attributes associated with the object. For valid values for extensible attributes, see {extattrs:values}.
-- `ext_attrs_all` (Map of String) All ext_attrs including Terraform Internal ID and inherited attributes.
+- `ext_attrs_all` (Map of String) All ext_attrs including inherited values.
 - `ipv6addr` (String) The IPv6 Address of the shared record.
 - `name` (String) Name for this shared record. This value can be in unicode format.
 - `shared_record_group` (String) The name of the shared record group in which the record resides.

--- a/docs/resources/sharedrecord_a.md
+++ b/docs/resources/sharedrecord_a.md
@@ -75,4 +75,4 @@ Optional:
 
 Read-Only:
 
-- `ext_attrs_all` (Map of String) All ext_attrs including Terraform Internal ID and inherited attributes.
+- `ext_attrs_all` (Map of String) All ext_attrs including inherited values.

--- a/docs/resources/sharedrecord_aaaa.md
+++ b/docs/resources/sharedrecord_aaaa.md
@@ -76,4 +76,4 @@ Optional:
 
 Read-Only:
 
-- `ext_attrs_all` (Map of String) All ext_attrs including Terraform Internal ID and inherited attributes.
+- `ext_attrs_all` (Map of String) All ext_attrs including inherited values.

--- a/internal/service/dns/model_sharedrecord_a.go
+++ b/internal/service/dns/model_sharedrecord_a.go
@@ -20,7 +20,6 @@ import (
 	coremodel "github.com/infobloxopen/terraform-provider-infoblox/internal/core/model/dns"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	immutable "github.com/infobloxopen/terraform-provider-infoblox/internal/planmodifiers/immutable"
-	importmod "github.com/infobloxopen/terraform-provider-infoblox/internal/planmodifiers/import"
 	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
@@ -101,10 +100,7 @@ var SharedrecordAResourceNiosSchemaAttributes = map[string]schema.Attribute{
 	"ext_attrs_all": schema.MapAttribute{
 		Computed:            true,
 		ElementType:         types.StringType,
-		MarkdownDescription: "All ext_attrs including Terraform Internal ID and inherited attributes.",
-		PlanModifiers: []planmodifier.Map{
-			importmod.AssociateInternalId(),
-		},
+		MarkdownDescription: "All ext_attrs including inherited values.",
 	},
 	"ipv4addr": schema.StringAttribute{
 		Required:   true,

--- a/internal/service/dns/model_sharedrecord_aaaa.go
+++ b/internal/service/dns/model_sharedrecord_aaaa.go
@@ -20,7 +20,6 @@ import (
 	coremodel "github.com/infobloxopen/terraform-provider-infoblox/internal/core/model/dns"
 	"github.com/infobloxopen/terraform-provider-infoblox/internal/flex"
 	immutable "github.com/infobloxopen/terraform-provider-infoblox/internal/planmodifiers/immutable"
-	importmod "github.com/infobloxopen/terraform-provider-infoblox/internal/planmodifiers/import"
 	customvalidator "github.com/infobloxopen/terraform-provider-infoblox/internal/validator"
 )
 
@@ -101,10 +100,7 @@ var SharedrecordAaaaResourceNiosSchemaAttributes = map[string]schema.Attribute{
 	"ext_attrs_all": schema.MapAttribute{
 		Computed:            true,
 		ElementType:         types.StringType,
-		MarkdownDescription: "All ext_attrs including Terraform Internal ID and inherited attributes.",
-		PlanModifiers: []planmodifier.Map{
-			importmod.AssociateInternalId(),
-		},
+		MarkdownDescription: "All ext_attrs including inherited values.",
 	},
 	"ipv6addr": schema.StringAttribute{
 		Required:   true,

--- a/internal/service/dns/sharedrecord_aaaa_resource.go
+++ b/internal/service/dns/sharedrecord_aaaa_resource.go
@@ -211,7 +211,7 @@ func (r *SharedrecordAaaaResource) Update(ctx context.Context, req resource.Upda
 
 	var planExtAttrs types.Map
 
-	// Merge ext_attrs with state ext_attrs_all (inherited EAs)
+	// Merge ext_attrs with state ext_attrs_all (inherited)
 	if r.backend == core.BackendNIOS {
 		var stateNIOSObj types.Object
 		diags = req.State.GetAttribute(ctx, path.Root("nios"), &stateNIOSObj)


### PR DESCRIPTION
Removed importmod Plan Modifier from objects that doesn't support Terraform Internal ID.